### PR TITLE
Support multiple threads per block in the CPU launcher

### DIFF
--- a/backend/driver.py
+++ b/backend/driver.py
@@ -223,7 +223,7 @@ static void _launch(int num_warps, int gridX, int gridY, int gridZ, kernel_ptr_t
 
         const unsigned block_start = consecutive_blocks * team_id;
 
-        const unsigned run_end = (block_start + consecutive_blocks < N) ? (block_start + consecutive_blocks) : N; 
+        const unsigned run_end = (block_start + consecutive_blocks < N) ? (block_start + consecutive_blocks) : N;
         for(unsigned i = block_start; i < run_end; i++) {{
             GridCoordinate coord = get_grid_coordinate(i, gridX, gridY, gridZ);
             (*kernel_ptr)({', '.join(kernel_params) if len(kernel_params) > 0 else ''});


### PR DESCRIPTION
Support multiple threads / block in the CPU launcher by introducing the concept of a "team". A team is a set of threads cooperatively executing a block. Each thread operates as a "warp", processing a contiguous region of data. Each thread in the team is mapped to a hardware thread via OpenMP. Blocks are chunked across teams. Within a team, each thread ID is fixed, and a thread simply processes each block in its team's chunk sequentially. In the event that the number of blocks does not divide evenly across teams, chunks are slightly oversized, and tails are handled explicitly with early termination.

OpenMP is now a required dependency and the threads are implemented via OpenMP parallel regions. 
