### PR TITLE
Introduce lowering to `llvm.masked` intrinsics for loads/stores

### DIFF
--- a/.github/patches/.pre-commit-config.yaml.patch
+++ b/.github/patches/.pre-commit-config.yaml.patch
@@ -1,0 +1,12 @@
+diff --git a/.pre-commit-config.yaml b/.pre-commit-config.yaml
+index 8462ab9..b910b47 100644
+--- a/.pre-commit-config.yaml
++++ b/.pre-commit-config.yaml
+@@ -72,5 +72,6 @@ exclude: |
+     ^third_party/amd/backend/include/roctracer/|
+     ^third_party/amd/backend/lib/|
+     ^third_party/nvidia/backend/include/cuda.h|
+-    ^third_party/f2reduce
++    ^third_party/f2reduce|
++    ^.github/patches
+   )

--- a/.github/patches/CMakeLists.txt.patch
+++ b/.github/patches/CMakeLists.txt.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index eadb62a15..ccc257731 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -197,6 +197,8 @@ if(TRITON_BUILD_PYTHON_MODULE)
+       cmake_path(APPEND TRITON_BINARY_DIR "third_party" ${PLUGIN_NAME} OUTPUT_VARIABLE PLUGIN_DIR_BUILD_OUTPUT)
+       message(STATUS "Building plugin '${PLUGIN_NAME}' from ${PLUGIN_DIR} with output ${PLUGIN_DIR_BUILD_OUTPUT}")
+       add_subdirectory(${PLUGIN_DIR} ${PLUGIN_DIR_BUILD_OUTPUT})
++      include_directories(${PLUGIN_DIR})
++      include_directories(${PROJECT_BINARY_DIR}/${PLUGIN_DIR_BUILD_OUTPUT})
+     endforeach()
+   endif()
+ 

--- a/.github/patches/RegisterTritonDialects.h.patch
+++ b/.github/patches/RegisterTritonDialects.h.patch
@@ -1,0 +1,33 @@
+diff --git a/bin/RegisterTritonDialects.h b/bin/RegisterTritonDialects.h
+index 4cd0834f8..e3951866b 100644
+--- a/bin/RegisterTritonDialects.h
++++ b/bin/RegisterTritonDialects.h
+@@ -39,6 +39,9 @@
+ #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
+ #include "mlir/InitAllPasses.h"
+ 
++#include "npu/include/Dialect/TritonCPU/IR/Dialect.h"
++#include "npu/include/TritonCPUToLLVM/Passes.h"
++
+ namespace mlir {
+ namespace test {
+ void registerTestAliasPass();
+@@ -122,6 +125,11 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
+   mlir::triton::proton::gpu::registerScheduleBufferStorePass();
+   mlir::triton::proton::gpu::registerAddSchedBarriersPass();
+ 
++  // NPU
++  mlir::triton::npu::registerConvertTritonCPUToLLVM();
++  mlir::triton::npu::registerAllocateSharedMemoryNPU();
++  mlir::triton::npu::registerConvertMaskedOpsToLLVM();
++
+   registry.insert<
+       mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,
+       mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect,
+@@ -133,5 +141,5 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
+       mlir::triton::amdgpu::TritonAMDGPUDialect,
+       mlir::triton::proton::ProtonDialect,
+       mlir::triton::proton::gpu::ProtonGPUDialect, mlir::ROCDL::ROCDLDialect,
+-      mlir::triton::gluon::GluonDialect>();
++      mlir::triton::gluon::GluonDialect, mlir::triton::cpu::TritonCPUDialect>();
+ }

--- a/.github/workflows/integration-tests-cpu.yml
+++ b/.github/workflows/integration-tests-cpu.yml
@@ -93,7 +93,10 @@ jobs:
         run: ccache --print-stats
       - name: Run lit tests
         working-directory: ./triton
-        run: make test-lit
+        run: |
+          make test-lit
+          export BUILD_DIR="$(cd python; python -c 'from build_helpers import get_cmake_dir; print(get_cmake_dir())')"
+          ninja -C ${BUILD_DIR} check-triton-npu-lit-tests
       - name: Run python tests on CPU
         working-directory: ./triton
         run: |

--- a/.github/workflows/integration-tests-macos.yml
+++ b/.github/workflows/integration-tests-macos.yml
@@ -117,6 +117,8 @@ jobs:
         run: |-
           source ~/.venv/bin/activate
           make test-lit
+          export BUILD_DIR="$(cd python; python -c 'from build_helpers import get_cmake_dir; print(get_cmake_dir())')"
+          ninja -C ${BUILD_DIR} check-triton-npu-lit-tests
       - name: Run python tests on CPU
         working-directory: ./triton
         run: |

--- a/.github/workflows/update-triton.yml
+++ b/.github/workflows/update-triton.yml
@@ -33,6 +33,10 @@ jobs:
           LATEST_COMMIT=$(git rev-parse HEAD)
           echo "Latest Triton commit hash: ${LATEST_COMMIT}"
           echo "${LATEST_COMMIT}" > ../triton.txt
+      - name: Apply Triton patches for pre-commit files
+        working-directory: ./triton
+        run: |
+          git apply -v ${GITHUB_WORKSPACE}/.github/patches/.pre-commit-config.yaml.patch
       - name: Compare hashes
         id: compare
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,5 +72,6 @@ exclude: |
     ^third_party/amd/backend/include/roctracer/|
     ^third_party/amd/backend/lib/|
     ^third_party/nvidia/backend/include/cuda.h|
-    ^third_party/f2reduce
+    ^third_party/f2reduce|
+    ^.github/patches
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/)
+
+set(triton_npu_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_subdirectory(npu)
 if(TRITON_BUILD_PYTHON_MODULE)
   add_triton_plugin(TritonNPU ${CMAKE_CURRENT_SOURCE_DIR}/triton_npu.cc LINK_LIBS TritonCPUToLLVM)
@@ -8,6 +11,8 @@ endif()
 if(TRITON_BUILD_UT)
   add_subdirectory(unittest)
 endif()
+
+add_subdirectory(test)
 
 # uKernel Libs
 

--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -138,6 +138,7 @@ class NPUBackend(BaseBackend):
         passes.convert.add_index_to_llvmir(pm)
 
         npu.passes.ttnpuir.add_to_llvmir(pm)
+        npu.passes.ttnpuir.add_masked_ops_to_llvm(pm)
         npu.passes.ttnpuir.add_shared_memory_global_conversion(pm)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)

--- a/npu/include/Dialect/TritonCPU/IR/Dialect.h
+++ b/npu/include/Dialect/TritonCPU/IR/Dialect.h
@@ -1,6 +1,7 @@
 #ifndef TRITON_DIALECT_TRITONCPU_IR_DIALECT_H_
 #define TRITON_DIALECT_TRITONCPU_IR_DIALECT_H_
 
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"

--- a/npu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
+++ b/npu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
@@ -6,6 +6,9 @@ include "mlir/Interfaces/SideEffectInterfaces.td" // Pure
 include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "triton/Dialect/Triton/IR/TritonAttrDefs.td"
 
+include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
+
+
 class TTC_Op<string mnemonic, list<Trait> traits = []> :
     Op<TritonCPU_Dialect, mnemonic,
        !listconcat(traits, [])> {
@@ -32,6 +35,47 @@ def TTC_BlockIdOp : TTC_Op<"block_id", [Pure]> {
     int32_t getAxisAsInt() {
       return static_cast<int32_t>(getAxis());
     }
+  }];
+}
+
+def TTC_MaskedLoadOp : TTC_Op<"masked_load", [
+  TypesMatchWith<"mask size matches false val size", "falseVal", "mask", "mlir::getI1SameShape($_self)">,
+  TypesMatchWith<"result type matches false val type", "result", "falseVal", "$_self">,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Masked load operation";
+
+  let description = [{
+    Load operation which lowers to a predicated load, scalar load, or masked vector load intrinsic.
+  }];
+
+  let arguments = (ins LLVM_AnyPointer:$ptr, AnyTypeOf<[LLVM_VectorOf<I1>, I1]>:$mask, AnyTypeOf<[LLVM_VectorOf<LLVM_Type>, LLVM_Type]>:$falseVal);
+
+  let results = (outs LLVM_Type:$result);
+
+  let assemblyFormat = [{
+    $ptr `,` $mask `,` $falseVal
+    attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def TTC_MaskedStoreOp : TTC_Op<"masked_store", [
+  TypesMatchWith<"mask type matches value type", "value", "mask",
+                 "mlir::getI1SameShape($_self)">
+]> {
+  let summary = "Masked store operation";
+
+  let description = [{
+    Store operation which conditionally lowers to the llvm.masked.store intrinsic, a predicated store, or a LLVM store if the mask is provably always true.
+  }];
+
+  let arguments = (ins LLVM_AnyPointer:$ptr, LLVM_Type:$value, AnyTypeOf<[LLVM_VectorOf<I1>, I1]>:$mask);
+
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $ptr `,` $value `,` $mask
+    attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/npu/include/TritonCPUToLLVM/Passes.h
+++ b/npu/include/TritonCPUToLLVM/Passes.h
@@ -2,6 +2,7 @@
 #define TRITONNPU_CONVERSION_TRITONCPUTOLLVM_PASSES_H
 
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 

--- a/npu/include/TritonCPUToLLVM/Passes.td
+++ b/npu/include/TritonCPUToLLVM/Passes.td
@@ -20,6 +20,20 @@ def ConvertTritonCPUToLLVM : Pass<"convert-triton-npu-to-llvm", "mlir::ModuleOp"
                              ];
 }
 
+def ConvertMaskedOpsToLLVM : Pass<"convert-masked-ops-to-llvm", "mlir::ModuleOp"> {
+    let summary = "Convert masked operations to LLVM";
+
+    let description = [{
+        The `convert-masked-ops-to-llvm` pass transforms TritonCPU masked operations
+        into equivalent LLVM instructions. This is done after ConvertTritonCPUToLLVM for debugging and observability purposes.
+    }];
+
+    let dependentDialects = ["mlir::arith::ArithDialect",
+                             "mlir::LLVM::LLVMDialect",
+                             "mlir::triton::cpu::TritonCPUDialect"
+                            ];
+}
+
 def AllocateSharedMemoryNPU : Pass<"allocate-shared-memory-npu", "mlir::ModuleOp"> {
     let summary = "Add metadata for NPU shared memory allocation";
 

--- a/npu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/npu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -1,5 +1,30 @@
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/Builders.h"
 #include "npu/include/Dialect/TritonCPU/IR/Dialect.h"
+
+namespace mlir {
+
+static Type getI1SameShape(Type type) {
+  Type i1Type = IntegerType::get(type.getContext(), 1);
+  if (LLVM::isCompatibleVectorType(type))
+    return LLVM::getVectorType(i1Type, LLVM::getVectorNumElements(type));
+  return i1Type;
+}
+
+namespace triton {
+namespace cpu {
+
+void MaskedLoadOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), &getPtrMutable(),
+                       GlobalMemory::get());
+}
+
+} // namespace cpu
+} // namespace triton
+
+} // namespace mlir
 
 #define GET_OP_CLASSES
 #include "npu/include/Dialect/TritonCPU/IR/Ops.cpp.inc"

--- a/npu/lib/TritonCPUToLLVM/CMakeLists.txt
+++ b/npu/lib/TritonCPUToLLVM/CMakeLists.txt
@@ -4,6 +4,7 @@ add_triton_library(TritonCPUToLLVM
     FuncOpToLLVM.cpp
     GPUOpToLLVM.cpp
     LoadStoreOpToLLVM.cpp
+    MaskedOpsToLLVM.cpp
     SharedMemoryGlobalConversion.cpp
     TritonCPUToLLVM.cpp
     TargetInfo.cpp

--- a/npu/lib/TritonCPUToLLVM/MaskedOpsToLLVM.cpp
+++ b/npu/lib/TritonCPUToLLVM/MaskedOpsToLLVM.cpp
@@ -1,0 +1,167 @@
+#include "npu/include/TritonCPUToLLVM/Passes.h"
+
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "npu/include/Dialect/TritonCPU/IR/Dialect.h"
+
+#define DEBUG_TYPE "masked-ops-to-llvm"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+
+class ConvertMaskedLoadOp : public OpRewritePattern<triton::cpu::MaskedLoadOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(triton::cpu::MaskedLoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
+    auto loc = loadOp.getLoc();
+    auto elemTy = loadOp.getType();
+    LDBG("Lowering masked load " << loadOp << " to LLVM");
+
+    auto ptr = loadOp.getPtr();
+    auto mask = loadOp.getMask();
+    auto other = loadOp.getFalseVal();
+
+    // masked load
+    if (auto vecTy = dyn_cast<VectorType>(elemTy)) {
+      LDBG("Vector masked load type: " << vecTy);
+      auto vecElemTy = vecTy.getElementType();
+      auto elemSizeInBytes = vecElemTy.getIntOrFloatBitWidth() / 8;
+      unsigned alignment = elemSizeInBytes * vecTy.getNumElements();
+      LDBG("ptrType = " << ptr.getType() << ", maskType = " << mask.getType()
+                        << ", otherType = " << other.getType()
+                        << ", alignment = " << alignment);
+      Value loadVal = rewriter.create<LLVM::MaskedLoadOp>(
+          loc, elemTy, ptr, mask, other, alignment);
+      rewriter.replaceOp(loadOp, {loadVal});
+      return success();
+    }
+
+    unsigned alignment =
+        std::max(8u, getElementTypeOrSelf(elemTy).getIntOrFloatBitWidth() / 8u);
+    // direct load
+    if (matchPattern(mask, m_One())) {
+      LDBG("Constant mask (" << mask << "), direct load type " << elemTy
+                             << " with alignment " << alignment);
+      Value loadVal =
+          rewriter.create<LLVM::LoadOp>(loc, elemTy, ptr, alignment);
+      rewriter.replaceOp(loadOp, loadVal);
+      return success();
+    }
+
+    // predicated load
+    LDBG("Predicated load with alignment " << alignment);
+    Block *currentBlock = rewriter.getInsertionBlock();
+    Block *afterLoad =
+        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+    afterLoad->addArgument({elemTy}, {loc});
+
+    Block *trueBlock = rewriter.createBlock(afterLoad);
+
+    rewriter.setInsertionPointToEnd(currentBlock);
+    rewriter.create<LLVM::CondBrOp>(loc, mask, trueBlock, ValueRange{},
+                                    afterLoad, ValueRange{other});
+    rewriter.setInsertionPointToStart(trueBlock);
+    auto load = rewriter.create<LLVM::LoadOp>(loc, elemTy, ptr, alignment);
+    rewriter.create<LLVM::BrOp>(loc, ValueRange{load.getResult()}, afterLoad);
+
+    Value loadResult = afterLoad->getArgument(0);
+    rewriter.replaceOp(loadOp, {loadResult});
+
+    return success();
+  }
+};
+
+class ConvertMaskedStoreOp
+    : public OpRewritePattern<triton::cpu::MaskedStoreOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(triton::cpu::MaskedStoreOp storeOp,
+                                PatternRewriter &rewriter) const override {
+    auto loc = storeOp.getLoc();
+    LDBG("Lowering masked store " << storeOp << " to LLVM");
+
+    auto ptr = storeOp.getPtr();
+    auto mask = storeOp.getMask();
+    auto val = storeOp.getValue();
+
+    auto elemTy = val.getType();
+    if (auto vecTy = dyn_cast<VectorType>(elemTy)) {
+      LDBG("Vector masked store type: " << vecTy);
+      auto vecElemTy = vecTy.getElementType();
+      auto elemSizeInBytes = vecElemTy.getIntOrFloatBitWidth() / 8;
+      unsigned alignment = elemSizeInBytes * vecTy.getNumElements();
+      LDBG("ptrType = " << ptr.getType() << ", maskType = " << mask.getType()
+                        << ", alignment = " << alignment);
+      rewriter.replaceOpWithNewOp<LLVM::MaskedStoreOp>(storeOp, val, ptr, mask,
+                                                       alignment);
+      return success();
+    }
+
+    unsigned alignment =
+        std::max(8u, getElementTypeOrSelf(elemTy).getIntOrFloatBitWidth() / 8u);
+    // direct store
+    if (matchPattern(mask, m_One())) {
+      LDBG("Constant mask (" << mask << "), direct load type " << elemTy
+                             << " with alignment " << alignment);
+      rewriter.create<LLVM::StoreOp>(loc, val, ptr, alignment);
+    } else {
+      LDBG("Predicated store with alignment " << alignment);
+      // default to predicated load with conditional branching
+      Block *currentBlock = rewriter.getInsertionBlock();
+      Block *afterStore =
+          rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+      Block *trueBlock = rewriter.createBlock(afterStore);
+      rewriter.setInsertionPointToEnd(currentBlock);
+      rewriter.create<LLVM::CondBrOp>(loc, mask, trueBlock, afterStore);
+      rewriter.setInsertionPointToStart(trueBlock);
+      rewriter.create<LLVM::StoreOp>(loc, val, ptr, alignment);
+      rewriter.create<LLVM::BrOp>(loc, afterStore);
+      rewriter.setInsertionPointToStart(afterStore);
+    }
+
+    rewriter.eraseOp(storeOp);
+    return success();
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+namespace npu {
+
+#define GEN_PASS_DEF_CONVERTMASKEDOPSTOLLVM
+#include "npu/include/TritonCPUToLLVM/Passes.h.inc"
+
+class ConvertMaskedOpsToLLVM
+    : public impl::ConvertMaskedOpsToLLVMBase<ConvertMaskedOpsToLLVM> {
+public:
+  using impl::ConvertMaskedOpsToLLVMBase<
+      ConvertMaskedOpsToLLVM>::ConvertMaskedOpsToLLVMBase;
+
+  void runOnOperation() override {
+
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+    RewritePatternSet patterns(context);
+
+    patterns.add<ConvertMaskedLoadOp>(patterns.getContext());
+    patterns.add<ConvertMaskedStoreOp>(patterns.getContext());
+
+    if (applyPatternsGreedily(mod, std::move(patterns)).failed())
+      signalPassFailure();
+  }
+};
+
+} // namespace npu
+} // namespace triton
+} // namespace mlir

--- a/npu/lib/TritonCPUToLLVM/Utility.h
+++ b/npu/lib/TritonCPUToLLVM/Utility.h
@@ -17,60 +17,6 @@ constexpr int kSharedMemoryOffset = -1;
 constexpr int kProgramIdArgsOffset = -6 + kSharedMemoryOffset;
 constexpr int kThreadIdOffset = -1 + kProgramIdArgsOffset;
 
-/// Create a predicated block, using \p cond as the condition and \p ops for the
-/// values supplied by the conditional branch to the exit block. The \p
-/// thenOpsFn function is used to inject operations in the 'then' branch:
-///   cf.cond_br %cond, ^br1, ^br2(%ops)
-///   ^br1:
-///     %then_ops = `thenOpsFn()`
-///     cf.br ^br2(%then_ops)
-///   ^br2(%block_ops):
-template <typename ThenOpsFn>
-Block &createPredicatedBlock(RewriterBase &rewriter, Location loc, Value cond,
-                             ArrayRef<Value> ops, ThenOpsFn &&thenOpsFn) {
-  Block *insertionBlock = rewriter.getInsertionBlock();
-  Block *thenBlock =
-      rewriter.splitBlock(insertionBlock, rewriter.getInsertionPoint());
-  Block *endBlock = rewriter.splitBlock(thenBlock, thenBlock->begin());
-
-  rewriter.setInsertionPointToEnd(insertionBlock);
-  rewriter.create<cf::CondBranchOp>(loc, cond, thenBlock, endBlock, ops);
-
-  rewriter.setInsertionPointToStart(thenBlock);
-  auto thenOps = thenOpsFn();
-  assert(thenOps.size() == ops.size() && "Inconsistent size");
-  assert(llvm::all_of(llvm::enumerate(ops, thenOps),
-                      [](const auto &enumerator) {
-                        auto [index, op, thenOp] = enumerator;
-                        return op.getType() == thenOp.getType();
-                      }) &&
-         "type mismatch found");
-
-  if (thenOps.empty())
-    rewriter.create<cf::BranchOp>(loc, endBlock);
-  else
-    rewriter.create<cf::BranchOp>(loc, endBlock, thenOps);
-
-  for (Value op : thenOps)
-    endBlock->addArgument(op.getType(), op.getLoc());
-
-  rewriter.setInsertionPointToStart(endBlock);
-  return *endBlock;
-}
-
-/// Create a predicated block, using \p cond as the condition and \p thenOpsFn
-/// to inject operations in the 'then' branch:
-///   cf.cond_br %cond, ^br1, ^br2
-///   ^br1:
-///     `thenOpsFn()`
-///     cf.br ^br2
-///   ^br2:
-template <typename ThenOpsFn>
-Block &createPredicatedBlock(RewriterBase &rewriter, Location loc, Value cond,
-                             ThenOpsFn &&thenOpsFn) {
-  return createPredicatedBlock(rewriter, loc, cond, {}, thenOpsFn);
-}
-
 // Returns a Value for the format string, which you can reuse. Writes the byte
 // count for the string to |formatStrByteCount| if not null.
 Value llPrintf(StringRef msg, ValueRange args, ArrayRef<bool> isSigned,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,29 @@
+llvm_canonicalize_cmake_booleans(
+  MLIR_ENABLE_BINDINGS_PYTHON
+)
+
+set(FILECHECK_PATH "${LLVM_LIBRARY_DIR}/../bin/FileCheck")
+set(LIT_ARGS "-Dfilecheck=${FILECHECK_PATH}")
+
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  MAIN_CONFIG
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+)
+
+set(TRITON_TEST_DEPENDS
+  triton-opt
+  triton-tensor-layout
+  triton-llvm-opt
+)
+
+add_lit_testsuite(check-triton-npu-lit-tests "Running the triton regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ARGS ${LIT_ARGS}
+  DEPENDS ${TRITON_TEST_DEPENDS}
+  )
+
+set_target_properties(check-triton-npu-lit-tests PROPERTIES FOLDER "Tests")
+
+add_lit_testsuites(TRITON-NPU-LIT-TESTS ${CMAKE_CURRENT_BINARY_DIR} DEPENDS ${TRITON_TEST_DEPENDS})

--- a/test/Conversion/load_store.mlir
+++ b/test/Conversion/load_store.mlir
@@ -1,0 +1,78 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory-npu --convert-triton-npu-to-llvm | FileCheck %s -check-prefix=MASKED-OP
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory-npu --convert-triton-npu-to-llvm -convert-masked-ops-to-llvm | FileCheck %s -check-prefix=LLVM
+
+// COM: Lowers tt.load and tt.store to TritonCPU masked_load/masked_store ops. Then re-runs the test suite lowering the masked ops to LLVM intrinsics.
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [1], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "npu", "ttg.threads-per-warp" = 1 : i32} {
+  tt.func public @kernel(%arg0: !tt.ptr<i32> {tt.divisibility = 8 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 8 : i32}) attributes {noinline = false} {
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<64x!tt.ptr<i32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<64x!tt.ptr<i32>, #blocked>, tensor<64xi32, #blocked>
+    %3 = tt.load %2 : tensor<64x!tt.ptr<i32>, #blocked>
+    // MASKED-OP: [[MASK:%.*]] = llvm.mlir.constant(dense<true> : vector<2xi1>) : vector<2xi1>
+    // MASKED-OP: [[OTHER:%.*]] = llvm.mlir.constant(dense<0> : vector<2xi32>) : vector<2xi32>
+    // MASKED-OP: triton_cpu.masked_load {{.*}}, [[MASK]], [[OTHER]] : {{.*}} -> vector<2xi32>
+    // MASKED-OP-COUNT-31: triton_cpu.masked_load
+    // MASKED-OP-NOT: triton_cpu.masked_load
+
+    // COM: Prevent the masked load op from being optimized out
+    tt.print " x: " {hex = false, isSigned = array<i32: 0>} : %3 : tensor<64xi32, #blocked>
+    // LLVM: [[OTHER:%.*]] = llvm.mlir.constant(dense<0> : vector<2xi32>) : vector<2xi32>
+    // LLVM: [[MASK:%.*]] = llvm.mlir.constant(dense<true> : vector<2xi1>) : vector<2xi1>
+    // LLVM-COUNT-32: llvm.intr.masked.load {{.*}}, [[MASK]], [[OTHER]] {alignment = 8 : i32} : {{.*}} -> vector<2xi32>
+    // LLVM-NOT: llvm.intr.masked.load
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [1], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "npu", "ttg.threads-per-warp" = 1 : i32} {
+    // LLVM-LABEL: masked_load_store
+    tt.func @masked_load_store(%x_ptr: !tt.ptr<f32> {tt.divisibility = 8 : i32}, %y_ptr: !tt.ptr<f32> {tt.divisibility = 8 : i32}, %n_elements: i32 {tt.divisibility = 8 : i32}) {
+        %offsets = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32, #blocked>
+        %n_elem_tensor = tt.splat %n_elements : i32 -> tensor<8xi32, #blocked>
+        %mask = arith.cmpi slt, %offsets, %n_elem_tensor : tensor<8xi32, #blocked>
+        %x_ptr_splat = tt.splat %x_ptr : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>, #blocked>
+        %x_tensor_of_ptr = tt.addptr %x_ptr_splat, %offsets : tensor<8x!tt.ptr<f32>, #blocked>, tensor<8xi32, #blocked>
+        // MASKED-OP-COUNT-4: triton_cpu.masked_load {{.*}} : {{.*}} -> vector<2xf32>
+        // MASKED-OP-NOT: triton_cpu.masked_load
+
+        // LLVM-COUNT-4: llvm.intr.masked.load {{.*}} {alignment = 8 : i32} : {{.*}} -> vector<2xf32>
+        %x_tensor = tt.load %x_tensor_of_ptr, %mask : tensor<8x!tt.ptr<f32>, #blocked>
+
+        %y_ptr_splat = tt.splat %y_ptr : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>, #blocked>
+        %y_tensor_of_ptr = tt.addptr %y_ptr_splat, %offsets : tensor<8x!tt.ptr<f32>, #blocked>, tensor<8xi32, #blocked>
+
+        // MASKED-OP-COUNT-4: triton_cpu.masked_store {{.*}}
+        // MASKED-OP-NOT: triton_cpu.masked_store
+
+        // LLVM-COUNT-4: llvm.intr.masked.store {{.*}} {alignment = 8 : i32} : vector<2xf32>, vector<2xi1> into !llvm.ptr<1>
+        tt.store %y_tensor_of_ptr, %x_tensor, %mask : tensor<8x!tt.ptr<f32>, #blocked>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked4 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [1], warpsPerCTA = [8], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 1 : i32} {
+  // MASKED-OP-LABEL: reduce_xor_max
+  tt.func @reduce_xor_max(%arg0: tensor<8xf32, #blocked4>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = arith.maxnumf %arg1, %arg2 : f32
+      tt.reduce.return %1 : f32
+    }) : (tensor<8xf32, #blocked4>) -> f32
+    // MASKED-OP: triton_cpu.masked_load {{.*}} -> f32
+    // MASKED-OP: triton_cpu.masked_store {{.*}} : (!llvm.ptr, f32, i1) -> ()
+    // MASKED-OP: @barrier
+
+    // LLVM-NOT: llvm.intr.masked
+    // LLVM: llvm.call @barrier
+    // LLVM: llvm.load {{.*}} {alignment = 8 : i64} : !llvm.ptr -> f32
+    tt.return
+  }
+}

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -1,0 +1,71 @@
+# -*- Python -*-
+# ruff: noqa: F821
+
+import os
+
+import lit.formats
+import lit.util
+from lit.llvm import llvm_config
+from lit.llvm.subst import ToolSubst
+
+# Configuration file for the 'lit' test runner
+
+# (config is an instance of TestingConfig created when discovering tests)
+# name: The name of this test suite
+config.name = 'TRITONNPU'
+
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = ['.mlir', '.ll']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.triton_obj_root, 'test')
+config.substitutions.append(('%PATH%', config.environment['PATH']))
+config.substitutions.append(("%shlibdir", config.llvm_shlib_dir))
+config.substitutions.append(("%shlibext", config.llvm_shlib_ext))
+
+llvm_config.with_system_environment(['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
+
+# llvm_config.use_default_substitutions()
+
+# excludes: A list of directories to exclude from the testsuite. The 'Inputs'
+# subdirectories contain auxiliary inputs for various tests in their parent
+# directories.
+config.excludes = ['Inputs', 'Examples', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.triton_obj_root, 'test')
+config.triton_tools_dir = os.path.join(config.triton_obj_root, 'bin')
+config.filecheck_dir = os.path.join(config.triton_obj_root, 'bin', 'FileCheck')
+
+# FileCheck -enable-var-scope is enabled by default in MLIR test
+# This option avoids to accidentally reuse variable across -LABEL match,
+# it can be explicitly opted-in by prefixing the variable name with $
+config.environment["FILECHECK_OPTS"] = "--enable-var-scope"
+
+tool_dirs = [config.triton_tools_dir, config.llvm_tools_dir, config.filecheck_dir]
+
+# Tweak the PATH to include the tools dir.
+for d in tool_dirs:
+    llvm_config.with_environment('PATH', d, append_path=True)
+tools = [
+    'triton-opt',
+    'triton-llvm-opt',
+    'mlir-translate',
+    'llc',
+    ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),
+]
+
+llvm_config.add_tool_substitutions(tools, tool_dirs)
+
+# TODO: what's this?
+llvm_config.with_environment('PYTHONPATH', [
+    os.path.join(config.mlir_binary_dir, 'python_packages', 'triton'),
+], append_path=True)

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -1,0 +1,23 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.triton_obj_root = "@triton_BINARY_DIR@"
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_lib_dir = "@LLVM_LIBS_DIR@"
+config.llvm_shlib_dir = "@CMAKE_LIBRARY_OUTPUT_DIRECTORY@"
+config.llvm_shlib_ext = "@CMAKE_SHARED_LIBRARY_SUFFIX@"
+config.llvm_exe_ext = "@EXEEXT@"
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+config.mlir_binary_dir = "@MLIR_BINARY_DIR@"
+config.python_executable = "@Python3_EXECUTABLE@"
+config.enable_bindings_python = @MLIR_ENABLE_BINDINGS_PYTHON@
+
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work
+lit_config.load_config(config, "@triton_npu_SOURCE_DIR@/test/lit.cfg.py")

--- a/triton_npu.cc
+++ b/triton_npu.cc
@@ -31,6 +31,9 @@ void init_triton_npu_passes_ttgpuir(py::module &&m) {
   m.def("add_shared_memory_global_conversion", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::npu::createSharedMemoryGlobalConversionPass());
   });
+  m.def("add_masked_ops_to_llvm", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::npu::createConvertMaskedOpsToLLVM());
+  });
 }
 
 void init_triton_npu(py::module &&m) {


### PR DESCRIPTION
Refactors the load store lowering code to use a newly introduced `TritonCPU::MaskedLoadOp`/`TritonCPU::MaskedStoreOp`. Loads/stores to/from shared memory and `tt.load`/`tt.store` ops are first lowered to masked load ops. Then, we lower masked load ops to LLVM in a separate pass. By taking the two-step approach we can separate the creation of the memory-level load from the optimization of the load (e.g. eliding the predicate if we it can be proven to always be true). The separation (vs rewrite patterns in the same pass) makes it much easier to debug or introspect the masked ops. 

I also introduced a lit test framework for the TritonNPU plugin that piggy-backs on the upstream tests. 