### PR TITLE
Use greedy rewriter during generic op fusion

### DIFF
--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -591,10 +591,16 @@ struct FuseConstantIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
           continue;
         unsigned argIdx = blockArg.getArgNumber();
         unsigned numIV = forOp.getNumInductionVars();
+
+        // Only safe to look through if the iter_arg is never modified
+        auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+        if (yieldOp.getOperand(argIdx - numIV) != blockArg)
+            continue;
+
         op = forOp.getInitArgs()[argIdx - numIV].getDefiningOp();
         if (!op)
 #endif
-          continue;
+        continue;
       }
       auto constantOp = dyn_cast<arith::ConstantOp>(op);
       if (!constantOp)

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -310,18 +310,7 @@ struct FuseMakeRangeIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
       SmallVector<int32_t> tileShape(tiledType.getShape());
       SmallVector<Value> newIns(genericOp.getIns());
 
-      IRMapping mapping;
-      // 1. Add new block args for source op inputs at body end
-      // (there should only be one operand but maybe we can share this common
-      // code across all patterns)
-      for (Value operand : makeRangeOp->getOperands()) {
-        newIns.push_back(operand);
-        mapping.map(operand, body->addArgument(
-                                 updateTensorType(operand.getType(), tileShape),
-                                 operand.getLoc()));
-      }
-
-      // 2. clone
+      // 1. clone (make range has no operands)
       rewriter.setInsertionPointToStart(body);
 
       auto resultType = makeRangeOp.getResult().getType();

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -438,6 +438,207 @@ void InputFuser::cloneOp(Operation *op, Chain &chain,
   mapping.map(op->getResults(), newOp->getResults());
 }
 
+struct FuseElementwiseIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
+  using OpRewritePattern<cpu::GenericOp>::OpRewritePattern;
+
+  static bool isFusibleElementwise(Operation *op) {
+    if (!op)
+      return false;
+    if (op->getNumResults() != 1)
+      return false;
+    if ((isa<arith::ArithDialect, math::MathDialect>(op->getDialect())) &&
+        op->hasTrait<OpTrait::Elementwise>())
+      return true;
+    if (isa<triton::AddPtrOp>(op))
+      return true;
+    if (isa<triton::SplatOp>(op))
+      return true;
+    // note: load isn't really "elementwise", but the tensor of ptrs can be
+    // indexed elementwise and the output truncated based on the input size, so
+    // we treat it as elementwise
+    if (isa<triton::LoadOp>(op))
+      return true;
+    return false;
+  }
+
+  LogicalResult
+  matchAndRewrite(cpu::GenericOp genericOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    Block *body = &genericOp.getBody().front();
+    unsigned numIV = genericOp.getNumInductionVars();
+
+    for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
+      Operation *op = insVal.getDefiningOp();
+      if (!isFusibleElementwise(op))
+        continue;
+
+      BlockArgument blockArg = body->getArgument(numIV + i);
+      auto tiledType = dyn_cast<RankedTensorType>(blockArg.getType());
+      if (!tiledType)
+        continue;
+
+      SmallVector<int32_t> tileShape(tiledType.getShape());
+      SmallVector<Value> newIns(genericOp.getIns());
+
+      IRMapping mapping;
+      // 1. Add new block args for source op inputs at body end
+      for (Value operand : op->getOperands()) {
+        newIns.push_back(operand);
+        mapping.map(operand, body->addArgument(
+                                 updateTensorType(operand.getType(), tileShape),
+                                 operand.getLoc()));
+      }
+
+      // 2. clone
+      rewriter.setInsertionPointToStart(body);
+      Operation *newOp = rewriter.clone(*op, mapping);
+      Type origResultType = newOp->getResult(0).getType();
+      newOp->getResult(0).setType(updateTensorType(origResultType, tileShape));
+
+      // 3. replace block arg and clean up
+      // note that newOp must have 1 and only 1 result due to isFusible above
+      blockArg.replaceAllUsesWith(newOp->getResult(0));
+      body->eraseArgument(numIV + i);
+      newIns.erase(newIns.begin() + i);
+
+      rewriter.modifyOpInPlace(
+          genericOp, [&]() { genericOp.getInsMutable().assign(newIns); });
+
+      return success();
+    }
+
+    return failure();
+  }
+};
+
+struct FuseMakeRangeIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
+  using OpRewritePattern<cpu::GenericOp>::OpRewritePattern;
+
+  LogicalResult
+  matchAndRewrite(cpu::GenericOp genericOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    Block *body = &genericOp.getBody().front();
+    unsigned numIV = genericOp.getNumInductionVars();
+
+    for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
+      Operation *op = insVal.getDefiningOp();
+      if (!op)
+        continue;
+      triton::MakeRangeOp makeRangeOp = dyn_cast<triton::MakeRangeOp>(op);
+      if (!makeRangeOp)
+        continue;
+
+      BlockArgument blockArg = body->getArgument(numIV + i);
+      auto tiledType = cast<RankedTensorType>(blockArg.getType());
+
+      SmallVector<int32_t> tileShape(tiledType.getShape());
+      SmallVector<Value> newIns(genericOp.getIns());
+
+      IRMapping mapping;
+      // 1. Add new block args for source op inputs at body end
+      // (there should only be one operand but maybe we can share this common
+      // code across all patterns)
+      for (Value operand : makeRangeOp->getOperands()) {
+        newIns.push_back(operand);
+        mapping.map(operand, body->addArgument(
+                                 updateTensorType(operand.getType(), tileShape),
+                                 operand.getLoc()));
+      }
+
+      // 2. clone
+      rewriter.setInsertionPointToStart(body);
+
+      auto resultType = makeRangeOp.getResult().getType();
+      auto newResultType = updateTensorType(resultType, tileShape);
+      cpu::MakeDynamicRangeOp makeDynamicRangeOp =
+          triton::cpu::MakeDynamicRangeOp::create(
+              rewriter, makeRangeOp.getLoc(), newResultType,
+              genericOp.getChunkOffset());
+
+      // 3. update existing uses
+      blockArg.replaceAllUsesWith(makeDynamicRangeOp.getResult());
+      body->eraseArgument(numIV + i);
+      newIns.erase(newIns.begin() + i);
+
+      rewriter.modifyOpInPlace(
+          genericOp, [&]() { genericOp.getInsMutable().assign(newIns); });
+      return success();
+    }
+    return failure();
+  }
+};
+
+struct FuseConstantIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
+  using OpRewritePattern<cpu::GenericOp>::OpRewritePattern;
+
+  LogicalResult
+  matchAndRewrite(cpu::GenericOp genericOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    Block *body = &genericOp.getBody().front();
+    unsigned numIV = genericOp.getNumInductionVars();
+
+    for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
+      Operation *op = insVal.getDefiningOp();
+      if (!op) {
+        // constant ops can be fused through loops, so check to see if we have a
+        // block argument
+        auto blockArg = dyn_cast<BlockArgument>(insVal);
+        if (blockArg) {
+          auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
+          if (forOp) {
+            unsigned argIdx = blockArg.getArgNumber();
+            unsigned numIV = forOp.getNumInductionVars();
+            Value loopIterInit = forOp.getInitArgs()[argIdx - numIV];
+            op = loopIterInit.getDefiningOp();
+            if (!op)
+              continue;
+          }
+        }
+
+        continue;
+      }
+      auto constantOp = dyn_cast<arith::ConstantOp>(op);
+      if (!constantOp)
+        continue;
+
+      auto resultTensorType =
+          dyn_cast<RankedTensorType>(constantOp.getResult().getType());
+      if (resultTensorType)
+        continue;
+
+      BlockArgument blockArg = body->getArgument(numIV + i);
+      auto tiledType = cast<RankedTensorType>(blockArg.getType());
+
+      SmallVector<int32_t> tileShape(tiledType.getShape());
+      SmallVector<Value> newIns(genericOp.getIns());
+
+      // 1. clone. constants have no operands to update
+      IRMapping mapping;
+      rewriter.setInsertionPointToStart(body);
+      auto newTensorType =
+          cast<RankedTensorType>(updateTensorType(resultTensorType, tileShape));
+      auto denseAttr = cast<DenseElementsAttr>(constantOp.getValue());
+      assert(denseAttr.isSplat() &&
+             "non-splat tensor constants not yet supported in fuseInputs");
+      auto newAttr = DenseElementsAttr::get(
+          newTensorType, *denseAttr.getValues<Attribute>().begin());
+      auto newConstant =
+          arith::ConstantOp::create(rewriter, constantOp.getLoc(), newAttr);
+
+      // 3. update existing uses
+      blockArg.replaceAllUsesWith(newConstant.getResult());
+      body->eraseArgument(numIV + i);
+      newIns.erase(newIns.begin() + i);
+
+      rewriter.modifyOpInPlace(
+          genericOp, [&]() { genericOp.getInsMutable().assign(newIns); });
+
+      return success();
+    }
+    return failure();
+  }
+};
+
 } // namespace
 
 struct TritonCPUTileAndFusePass
@@ -459,6 +660,18 @@ struct TritonCPUTileAndFusePass
     }
 
     // Step 2: Fuse elementwise ops and loads into each generic
+#if 1
+    RewritePatternSet fusePatterns(context);
+
+    fusePatterns.add<FuseElementwiseIntoGeneric>(context, benefitDefault);
+    fusePatterns.add<FuseMakeRangeIntoGeneric>(context, benefitDefault);
+    fusePatterns.add<FuseConstantIntoGeneric>(context, benefitDefault);
+
+    if (applyPatternsGreedily(m, std::move(fusePatterns)).failed()) {
+      signalPassFailure();
+    }
+
+#else
     SmallVector<cpu::GenericOp> worklist;
     m.walk([&](cpu::GenericOp op) { worklist.push_back(op); });
     IRRewriter rewriter(context);
@@ -467,6 +680,7 @@ struct TritonCPUTileAndFusePass
       if (fuser.run().failed())
         signalPassFailure();
     }
+#endif
   }
 };
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -363,7 +363,6 @@ struct FuseConstantIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
       SmallVector<Value> newIns(genericOp.getIns());
 
       // 1. clone. constants have no operands to update
-      IRMapping mapping;
       rewriter.setInsertionPointToStart(body);
       auto newTensorType =
           cast<RankedTensorType>(updateTensorType(resultTensorType, tileShape));

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -214,230 +214,6 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
   }
 };
 
-// Returns true if defOp can be cloned into a generic body during fusion.
-// Reduction generics (cpu::GenericOp with scalar results) are not fusible —
-// their scalar outputs become params of the consumer, not tiled ins.
-static bool isFusible(Operation *defOp) {
-  if (!defOp)
-    return false;
-  if (isa<arith::ConstantOp>(defOp))
-    return true;
-  if ((isa<arith::ArithDialect, math::MathDialect>(defOp->getDialect())) &&
-      defOp->hasTrait<OpTrait::Elementwise>())
-    return true;
-  if (isa<triton::AddPtrOp>(defOp))
-    return true;
-  if (isa<triton::LoadOp>(defOp))
-    return true;
-  // tt.splat broadcasts a scalar to a tensor; the scalar input becomes a param.
-  if (isa<triton::SplatOp>(defOp))
-    return true;
-  // tt.make_range can be fused by rewriting make_range to
-  // ttc.make_dynamic_range, taking the chunk offset as a parameter
-  if (isa<triton::MakeRangeOp>(defOp))
-    return true;
-  return false;
-}
-
-// If v is a block argument of an scf.for (i.e. an iter_arg), return the
-// corresponding initial value passed to the loop. Otherwise return v unchanged.
-// This lets the fusion worklist see through loop-carried values to their
-// defining ops (e.g. constants used as iter_arg initialisers).
-static Value getIterArgInit(Value v) {
-  auto blockArg = dyn_cast<BlockArgument>(v);
-  if (!blockArg)
-    return v;
-  auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
-  if (!forOp)
-    return v;
-  unsigned argIdx = blockArg.getArgNumber();
-  unsigned numIV = forOp.getNumInductionVars();
-  if (argIdx < numIV || (argIdx - numIV) >= forOp.getInitArgs().size())
-    return v;
-  return forOp.getInitArgs()[argIdx - numIV];
-}
-
-class InputFuser {
-public:
-  InputFuser(IRRewriter &rewriter, cpu::GenericOp genericOp)
-      : rewriter(rewriter), genericOp(genericOp) {}
-
-  LogicalResult run();
-
-private:
-  struct Chain {
-    Value root;
-    unsigned insIdx;
-    SmallVector<int32_t> tileShape;
-  };
-
-  SmallVector<Operation *> collectChain(Chain &chain);
-
-  void cloneOp(Operation *op, Chain &chain, SmallVector<Value> &newIns,
-               SmallVector<unsigned> &insIdxToRemove, IRMapping &mapping);
-
-  IRRewriter &rewriter;
-  cpu::GenericOp genericOp;
-};
-
-LogicalResult InputFuser::run() {
-  Block *body = &genericOp.getBody().front();
-  unsigned numIV = genericOp.getNumInductionVars();
-
-  SmallVector<Value> newIns(genericOp.getIns());
-  SmallVector<unsigned> insIdxToRemove;
-
-  for (auto [insIdx, root] : llvm::enumerate(genericOp.getIns())) {
-    BlockArgument blockArg = body->getArgument(numIV + insIdx);
-    auto tensorTy = dyn_cast<RankedTensorType>(blockArg.getType());
-    // only fuse tensor inputs
-    if (!tensorTy)
-      continue;
-
-    SmallVector<int32_t> tileShape(tensorTy.getShape());
-    Chain chain{root, (unsigned)insIdx, tileShape};
-    SmallVector<Operation *> sorted = collectChain(chain);
-    if (sorted.empty())
-      continue;
-
-    IRMapping mapping;
-    rewriter.setInsertionPointToStart(body);
-    for (Operation *op : sorted) {
-      cloneOp(op, chain, newIns, insIdxToRemove, mapping);
-    }
-  }
-
-  llvm::sort(insIdxToRemove);
-  for (unsigned idx : llvm::reverse(insIdxToRemove)) {
-    body->eraseArgument(idx + numIV);
-    newIns.erase(newIns.begin() + idx);
-  }
-
-  rewriter.modifyOpInPlace(genericOp,
-                           [&]() { genericOp.getInsMutable().assign(newIns); });
-
-  return success();
-}
-
-SmallVector<Operation *> InputFuser::collectChain(Chain &chain) {
-  SetVector<Operation *> opsToFuse;
-
-  SmallVector<Value> worklist{chain.root};
-  while (!worklist.empty()) {
-    Value v = worklist.pop_back_val();
-    // See through scf.for iter_args to their initial values so we can fuse
-    // the ops that produce those values (e.g. constants used as initialisers).
-    Operation *defOp = getIterArgInit(v).getDefiningOp();
-    if (!defOp || !isFusible(defOp) || opsToFuse.contains(defOp))
-      continue;
-    opsToFuse.insert(defOp);
-    for (Value operand : defOp->getOperands())
-      worklist.push_back(operand);
-  }
-
-  // Sort opsToFuse into true topological order (defs before uses).
-  // The worklist DFS can insert the same dependency via two different paths
-  // (diamond-shaped graphs), so reversing the insertion order is not
-  // guaranteed to give a valid topo order.  We do an explicit post-order DFS.
-  SmallVector<Operation *> sortedOps;
-  DenseSet<Operation *> visited;
-  std::function<void(Operation *)> visit = [&](Operation *op) {
-    if (!opsToFuse.contains(op) || visited.contains(op))
-      return;
-    visited.insert(op);
-    for (Value operand : op->getOperands()) {
-      if (auto *def = operand.getDefiningOp())
-        visit(def);
-      // Also follow scf.for iter_arg initialisers.
-      Value init = getIterArgInit(operand);
-      if (init != operand)
-        if (auto *def = init.getDefiningOp())
-          visit(def);
-    }
-    sortedOps.push_back(op);
-  };
-  for (Operation *op : opsToFuse)
-    visit(op);
-
-  return sortedOps;
-}
-
-void InputFuser::cloneOp(Operation *op, Chain &chain,
-                         SmallVector<Value> &newIns,
-                         SmallVector<unsigned> &insIdxToRemove,
-                         IRMapping &mapping) {
-  Block *body = &genericOp.getBody().front();
-  unsigned numIV = genericOp.getNumInductionVars();
-
-  // chain.root may be an scf.for iter_arg; the defining op produces the init
-  // value, not root itself. Treat both as equivalent for block arg replacement.
-  Value effectiveRoot = getIterArgInit(chain.root);
-
-  auto replaceRootIfMatch = [&](Value origResult, Value clonedResult) {
-    if (origResult != effectiveRoot)
-      return;
-    body->getArgument(numIV + chain.insIdx).replaceAllUsesWith(clonedResult);
-    insIdxToRemove.push_back(chain.insIdx);
-    // Also map root (the iter_arg) so downstream ops resolve through the
-    // mapping rather than falling through to the "add as new ins" path.
-    if (effectiveRoot != chain.root)
-      mapping.map(chain.root, clonedResult);
-  };
-
-  // make range must be replaced with make dynamic range which takes the current
-  // tile offset as a parameter
-  if (auto makeRangeOp = dyn_cast<triton::MakeRangeOp>(op)) {
-    auto resultType = makeRangeOp.getResult().getType();
-    auto newResultType = updateTensorType(resultType, chain.tileShape);
-    auto makeDynamicRangeOp = triton::cpu::MakeDynamicRangeOp::create(
-        rewriter, makeRangeOp.getLoc(), newResultType,
-        genericOp.getChunkOffset());
-    mapping.map(makeRangeOp->getResults(), makeDynamicRangeOp->getResults());
-    replaceRootIfMatch(makeRangeOp.getResult(), makeDynamicRangeOp.getResult());
-    return;
-  }
-
-  // constant ops with tensor type get replaced with a constant op using the
-  // tile size
-  if (auto constantOp = dyn_cast<arith::ConstantOp>(op)) {
-    auto resultTensorType =
-        dyn_cast<RankedTensorType>(constantOp.getResult().getType());
-    if (resultTensorType) {
-      auto newTensorType = cast<RankedTensorType>(
-          updateTensorType(resultTensorType, chain.tileShape));
-      auto denseAttr = cast<DenseElementsAttr>(constantOp.getValue());
-      assert(denseAttr.isSplat() &&
-             "non-splat tensor constants not yet supported in fuseInputs");
-      auto newAttr = DenseElementsAttr::get(
-          newTensorType, *denseAttr.getValues<Attribute>().begin());
-      auto newConstant =
-          arith::ConstantOp::create(rewriter, constantOp.getLoc(), newAttr);
-      mapping.map(constantOp.getResult(), newConstant.getResult());
-      replaceRootIfMatch(constantOp.getResult(), newConstant.getResult());
-      return;
-    }
-  }
-
-  // general case - clone op
-  for (Value operand : op->getOperands()) {
-    if (mapping.contains(operand))
-      continue;
-
-    newIns.push_back(operand);
-    mapping.map(operand, body->addArgument(updateTensorType(operand.getType(),
-                                                            chain.tileShape),
-                                           operand.getLoc()));
-  }
-
-  Operation *newOp = rewriter.clone(*op, mapping);
-  for (auto [origResult, newResult] :
-       llvm::zip(op->getResults(), newOp->getResults())) {
-    newResult.setType(updateTensorType(newResult.getType(), chain.tileShape));
-    replaceRootIfMatch(origResult, newResult);
-  }
-  mapping.map(op->getResults(), newOp->getResults());
-}
-
 struct FuseElementwiseIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
   using OpRewritePattern<cpu::GenericOp>::OpRewritePattern;
 
@@ -579,29 +355,9 @@ struct FuseConstantIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
 
     for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
       Operation *op = insVal.getDefiningOp();
-      if (!op) {
-#if 0
-        // constant ops can be fused through loops, so check to see if we have a
-        // block argument
-        auto blockArg = dyn_cast<BlockArgument>(insVal);
-        if (!blockArg)
-          continue;
-        auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
-        if (!forOp)
-          continue;
-        unsigned argIdx = blockArg.getArgNumber();
-        unsigned numIV = forOp.getNumInductionVars();
-
-        // Only safe to look through if the iter_arg is never modified
-        auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-        if (yieldOp.getOperand(argIdx - numIV) != blockArg)
-            continue;
-
-        op = forOp.getInitArgs()[argIdx - numIV].getDefiningOp();
-        if (!op)
-#endif
+      if (!op)
         continue;
-      }
+
       auto constantOp = dyn_cast<arith::ConstantOp>(op);
       if (!constantOp)
         continue;
@@ -665,7 +421,6 @@ struct TritonCPUTileAndFusePass
     }
 
     // Step 2: Fuse elementwise ops and loads into each generic
-#if 1
     RewritePatternSet fusePatterns(context);
 
     fusePatterns.add<FuseElementwiseIntoGeneric>(context, benefitDefault);
@@ -675,17 +430,6 @@ struct TritonCPUTileAndFusePass
     if (applyPatternsGreedily(m, std::move(fusePatterns)).failed()) {
       signalPassFailure();
     }
-
-#else
-    SmallVector<cpu::GenericOp> worklist;
-    m.walk([&](cpu::GenericOp op) { worklist.push_back(op); });
-    IRRewriter rewriter(context);
-    for (cpu::GenericOp genericOp : llvm::reverse(worklist)) {
-      InputFuser fuser(rewriter, genericOp);
-      if (fuser.run().failed())
-        signalPassFailure();
-    }
-#endif
   }
 };
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -580,22 +580,21 @@ struct FuseConstantIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
     for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
       Operation *op = insVal.getDefiningOp();
       if (!op) {
+#if 0
         // constant ops can be fused through loops, so check to see if we have a
         // block argument
         auto blockArg = dyn_cast<BlockArgument>(insVal);
-        if (blockArg) {
-          auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
-          if (forOp) {
-            unsigned argIdx = blockArg.getArgNumber();
-            unsigned numIV = forOp.getNumInductionVars();
-            Value loopIterInit = forOp.getInitArgs()[argIdx - numIV];
-            op = loopIterInit.getDefiningOp();
-            if (!op)
-              continue;
-          }
-        }
-
-        continue;
+        if (!blockArg)
+          continue;
+        auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
+        if (!forOp)
+          continue;
+        unsigned argIdx = blockArg.getArgNumber();
+        unsigned numIV = forOp.getNumInductionVars();
+        op = forOp.getInitArgs()[argIdx - numIV].getDefiningOp();
+        if (!op)
+#endif
+          continue;
       }
       auto constantOp = dyn_cast<arith::ConstantOp>(op);
       if (!constantOp)
@@ -603,7 +602,7 @@ struct FuseConstantIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
 
       auto resultTensorType =
           dyn_cast<RankedTensorType>(constantOp.getResult().getType());
-      if (resultTensorType)
+      if (!resultTensorType)
         continue;
 
       BlockArgument blockArg = body->getArgument(numIV + i);

--- a/test/Transform/tile_and_fuse.mlir
+++ b/test/Transform/tile_and_fuse.mlir
@@ -66,36 +66,3 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     tt.return
   }
 }
-
-// -----
-
-// TODO: is this valid??
-// Iter-arg fusion: %init (tt.make_range) is the init value of an scf.for
-// iter_arg. The generic inside the loop takes the iter_arg as ins. The fuser
-// must see through the iter_arg to its init op and replace the block argument,
-// rather than leaving the iter_arg as an unfused ins. Without the fix, the
-// make_dynamic_range would be emitted but never replace the block arg, leaving
-// a dead clone.
-//
-// CHECK-LABEL: tt.func public @test_iter_arg_fusion
-// CHECK:       scf.for
-// CHECK:         ttc.generic
-// CHECK-NOT:       tensor<4xi32
-// CHECK:           ttc.make_dynamic_range
-
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [1], warpsPerCTA = [1], order = [0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
-  tt.func public @test_iter_arg_fusion(%ptr: !tt.ptr<i32>, %n: i32) attributes {noinline = false, ttc.persistent_kernel} {
-    %c0 = arith.constant 0 : i32
-    %c1 = arith.constant 1 : i32
-    %c10 = arith.constant 10 : i32
-    %init = tt.make_range {start = 0 : i32, end = 4 : i32} : tensor<4xi32, #blocked>
-    scf.for %bid = %c0 to %c10 step %c1 iter_args(%carried = %init) -> (tensor<4xi32, #blocked>) : i32 {
-      %base = tt.splat %ptr : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>, #blocked>
-      %ptrs = tt.addptr %base, %carried : tensor<4x!tt.ptr<i32>, #blocked>, tensor<4xi32, #blocked>
-      tt.store %ptrs, %carried : tensor<4x!tt.ptr<i32>, #blocked>
-      scf.yield %carried : tensor<4xi32, #blocked>
-    }
-    tt.return
-  }
-}

--- a/test/Transform/tile_and_fuse.mlir
+++ b/test/Transform/tile_and_fuse.mlir
@@ -7,8 +7,8 @@
 // CHECK-LABEL: tt.func public @test_basic_fusion
 // CHECK:       ttc.generic
 // CHECK-NOT:     tensor<4x!tt.ptr<f32>
-// CHECK:         tt.splat
 // CHECK:         ttc.make_dynamic_range
+// CHECK:         tt.splat
 // CHECK:         tt.addptr
 // CHECK:         tt.load
 // CHECK:         tt.store
@@ -69,6 +69,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 
 // -----
 
+// TODO: is this valid??
 // Iter-arg fusion: %init (tt.make_range) is the init value of an scf.for
 // iter_arg. The generic inside the loop takes the iter_arg as ins. The fuser
 // must see through the iter_arg to its init op and replace the block argument,


### PR DESCRIPTION
Previously we materialized per-operand chains and fused each chain op-by-op. This requires a lot of tricky state handling which gets even worse for 2D tensor ops. Instead of fusing the entire chain, we can leverage the MLIR greedy pattern rewriter driver to greedily fuse each individual op. This drops the analysis part of the input fuser and replaces the clone with distinct rewrite patterns for each type of op we want to clone. Currently, we provide a generic "element wise" clone and handle make range / constant op separately (make range gets replaced with make dynamic range, constant gets re-created with a smaller tensor value). 

I also dropped a block args lit test that looks fishy. Cloning captured iter arg ops is dangerous since we don't know if those values are modified later in the block. The existing test cases pass fine without the fancy block args handling. If needed we can re-visit this for the dot case. 