### PR TITLE
Support `tt.dot` in `ttc.generic`

### DIFF
--- a/.github/workflows/integration-tests-cpu.yml
+++ b/.github/workflows/integration-tests-cpu.yml
@@ -112,7 +112,6 @@ jobs:
           TRITON_DEFAULT_BACKEND: "cpu"
         run: |
             TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python ../python/tutorials/02-fused-softmax.py
-            python ../python/tutorials/03-matrix-multiplication.py
             TRITON_CPU_ENABLE_TILE_AND_FUSE=1 TRITON_ALWAYS_COMPILE=1 python ../python/tutorials/03-matrix-multiplication.py
 
       # Triton tests.

--- a/.github/workflows/integration-tests-cpu.yml
+++ b/.github/workflows/integration-tests-cpu.yml
@@ -113,6 +113,7 @@ jobs:
         run: |
             TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python ../python/tutorials/02-fused-softmax.py
             python ../python/tutorials/03-matrix-multiplication.py
+            TRITON_CPU_ENABLE_TILE_AND_FUSE=1 TRITON_ALWAYS_COMPILE=1 python ../python/tutorials/03-matrix-multiplication.py
 
       # Triton tests.
       - name: Run lit tests

--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -142,7 +142,8 @@ class CPUBackend(BaseBackend):
         else:
             cpu.passes.ttgpuir.add_coalesce(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
-        cpu.passes.ttgpuir.add_accelerate_matmul(pm)
+        if options.tile_and_fuse is False:
+            cpu.passes.ttgpuir.add_accelerate_matmul(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
 
         passes.ttgpuir.add_optimize_thread_locality(pm)

--- a/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
+++ b/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
@@ -246,8 +246,8 @@ def TTC_GenericOp : TTC_Op<"generic", [RecursiveMemoryEffects, RecursivelySpecul
   }];
 
   let extraClassDeclaration = [{
-    Value getChunkOffset() { return getBody().front().getArgument(0); }
-    unsigned getNumInductionVars() { return 1; }
+    Value getTileOffset(unsigned dim) { return getBody().front().getArgument(dim); }
+    unsigned getNumInductionVars() { return getBlockShape().size(); }
     unsigned getNumRegionIterArgs() {
       return getBody().front().getNumArguments() - getNumInductionVars();
     }

--- a/cpu/lib/Analysis/AxisInfo.cpp
+++ b/cpu/lib/Analysis/AxisInfo.cpp
@@ -59,14 +59,16 @@ void CpuAxisInfoAnalysis::visitGenericOpArguments(
   auto tileShape = genericOp.getTileShape();
 
   // handle the induction var / tile offset separately
-  {
+  assert(tileShape.size() == genericOp.getNumInductionVars() &&
+         "expected number of induction vars to match tile shape rank");
+  for (unsigned i = 0; i < genericOp.getNumInductionVars(); i++) {
     AxisInfo::DimVectorT knownContiguity(1, 1);
     AxisInfo::DimVectorT knownDivisibility(1, 1);
     AxisInfo::DimVectorT knownConstancy(1, 1);
-    knownDivisibility[0] = tileShape[0]; // TODO: multi-dim support
+    knownDivisibility[0] = tileShape[i];
     auto inductionVar =
         AxisInfo(knownContiguity, knownDivisibility, knownConstancy);
-    propagateIfChanged(argLattices[0], argLattices[0]->join(inductionVar));
+    propagateIfChanged(argLattices[i], argLattices[i]->join(inductionVar));
   }
 
   for (auto [operand, argLattice] :

--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -54,6 +54,7 @@ LogicalResult GenericOp::verify() {
     }
   }
 
+#if 0
   // all operands must have the same encoding
   Attribute tensorEncoding;
   for (auto operand : getOperands()) {
@@ -66,6 +67,7 @@ LogicalResult GenericOp::verify() {
       tensorEncoding = tensorTy.getEncoding();
     }
   }
+#endif
 
   // Body must exist and have the implicit induction variable arguments.
   Region &body = getBody();

--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -26,7 +26,7 @@ LogicalResult GenericOp::verify() {
   auto tileShape = getTileShape();
 
   if (blockShape.size() < 1)
-    return emitOpError("must provide a non-empty block/vector shape");
+    return emitOpError("must provide a non-empty block/tile shape");
 
   if (blockShape.size() != tileShape.size()) {
     return emitOpError(
@@ -53,21 +53,6 @@ LogicalResult GenericOp::verify() {
              << " vs " << tileShape[i];
     }
   }
-
-#if 0
-  // all operands must have the same encoding
-  Attribute tensorEncoding;
-  for (auto operand : getOperands()) {
-    if (auto tensorTy = dyn_cast<RankedTensorType>(operand.getType())) {
-      if (tensorEncoding && tensorEncoding != tensorTy.getEncoding())
-        return emitOpError("expects all tensor operands to have the same "
-                           "encoding, got ")
-               << tensorTy.getEncoding() << " with previous encoding "
-               << tensorEncoding;
-      tensorEncoding = tensorTy.getEncoding();
-    }
-  }
-#endif
 
   // Body must exist and have the implicit induction variable arguments.
   Region &body = getBody();

--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -25,11 +25,8 @@ LogicalResult GenericOp::verify() {
   auto blockShape = getBlockShape();
   auto tileShape = getTileShape();
 
-  if (blockShape.size() != 1) {
-    return emitOpError(
-               "only rank-1 generic ops are currently supported, got rank ")
-           << blockShape.size();
-  }
+  if (blockShape.size() < 1)
+    return emitOpError("must provide a non-empty block/vector shape");
 
   if (blockShape.size() != tileShape.size()) {
     return emitOpError(
@@ -54,6 +51,19 @@ LogicalResult GenericOp::verify() {
       return emitOpError("expects blockShape[")
              << i << "] % tileShape[" << i << "] == 0, got " << blockShape[i]
              << " vs " << tileShape[i];
+    }
+  }
+
+  // all operands must have the same encoding
+  Attribute tensorEncoding;
+  for (auto operand : getOperands()) {
+    if (auto tensorTy = dyn_cast<RankedTensorType>(operand.getType())) {
+      if (tensorEncoding && tensorEncoding != tensorTy.getEncoding())
+        return emitOpError("expects all tensor operands to have the same "
+                           "encoding, got ")
+               << tensorTy.getEncoding() << " with previous encoding "
+               << tensorEncoding;
+      tensorEncoding = tensorTy.getEncoding();
     }
   }
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -730,7 +730,6 @@ struct FuseMakeRangeIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
         newOp = rewriter.clone(*op, mapping);
       } else {
         auto newResultType = updateTensorType(resultType, tileShape);
-        // TODO: get the right slice chunk offset
         auto sliceEncodingAttr =
             dyn_cast<triton::gpu::SliceEncodingAttr>(resultType.getEncoding());
         unsigned dim = sliceEncodingAttr ? sliceEncodingAttr.getDim() : 0;

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -716,18 +716,32 @@ struct FuseMakeRangeIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
 
       auto resultType =
           cast<RankedTensorType>(makeRangeOp.getResult().getType());
-      auto newResultType = updateTensorType(resultType, tileShape);
-      // TODO: get the right slice chunk offset
-      auto sliceEncodingAttr =
-          dyn_cast<triton::gpu::SliceEncodingAttr>(resultType.getEncoding());
-      unsigned dim = sliceEncodingAttr ? sliceEncodingAttr.getDim() : 0;
-      cpu::MakeDynamicRangeOp makeDynamicRangeOp =
-          triton::cpu::MakeDynamicRangeOp::create(
-              rewriter, makeRangeOp.getLoc(), newResultType,
-              genericOp.getTileOffset(dim));
+
+      const bool isNotTiled = llvm::all_of(
+          llvm::zip(tileShape, resultType.getShape()), [](auto pair) {
+            auto [t, s] = pair;
+            return t == s;
+          });
+
+      IRMapping mapping;
+      Operation *newOp;
+      if (isNotTiled) {
+        // just fuse the existing op
+        newOp = rewriter.clone(*op, mapping);
+      } else {
+        auto newResultType = updateTensorType(resultType, tileShape);
+        // TODO: get the right slice chunk offset
+        auto sliceEncodingAttr =
+            dyn_cast<triton::gpu::SliceEncodingAttr>(resultType.getEncoding());
+        unsigned dim = sliceEncodingAttr ? sliceEncodingAttr.getDim() : 0;
+        newOp = triton::cpu::MakeDynamicRangeOp::create(
+            rewriter, makeRangeOp.getLoc(), newResultType,
+            genericOp.getTileOffset(dim));
+      }
+      assert(newOp && "expected make range op to be replaced or fused");
 
       // 3. update existing uses
-      blockArg.replaceAllUsesWith(makeDynamicRangeOp.getResult());
+      blockArg.replaceAllUsesWith(newOp->getResult(0));
       body->eraseArgument(numIV + i);
       newIns.erase(newIns.begin() + i);
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -44,16 +44,25 @@ getBlockAndTileShapes(RankedTensorType tensorTy,
   return {blockShape, tileShape};
 }
 
+struct TiledInput {
+  Value value;
+  SmallVector<int32_t> shape;
+};
+
 // Create the body block of a GenericOp, adding one block arg per ins value
 // with tensor types replaced to the vector (chunk) shape. Populates `mapping`
 // with ins value → block arg entries and sets the insertion point to the start
 // of the block. Returns the new block.
 static Block *initGenericBody(OpBuilder &rewriter, cpu::GenericOp generic,
-                              ArrayRef<Value> ins, ArrayRef<int32_t> tileShape,
-                              IRMapping &mapping) {
+                              ArrayRef<TiledInput> ins,
+                              ArrayRef<int32_t> tileShape, IRMapping &mapping) {
   Block *body = rewriter.createBlock(&generic.getBody());
-  body->addArgument(rewriter.getI32Type(), generic.getLoc()); // chunk offset
-  for (Value v : ins) {
+  for (unsigned i = 0; i < tileShape.size(); i++)
+    body->addArgument(rewriter.getI32Type(),
+                      generic.getLoc()); // tile offset per vector shape dim
+
+  for (auto pair : ins) {
+    auto [v, tileShape] = pair;
     Type argTy = updateTensorType(v.getType(), tileShape);
     mapping.map(v, body->addArgument(argTy, v.getLoc()));
   }
@@ -82,11 +91,17 @@ struct WrapStores : public mlir::OpRewritePattern<triton::StoreOp> {
 
     auto [blockShape, tileShape] = getBlockAndTileShapes(tensorTy, encoding);
 
-    SmallVector<Value> ins(storeOp->getOperands().begin(),
-                           storeOp->getOperands().end());
+    SmallVector<TiledInput> ins;
+    for (auto value : storeOp->getOperands()) {
+      ins.push_back(TiledInput{value, tileShape});
+    }
 
-    auto generic = cpu::GenericOp::create(
-        rewriter, loc, /*resultTypes=*/TypeRange{}, ins, blockShape, tileShape);
+    SmallVector<Value> insValues =
+        llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
+
+    auto generic =
+        cpu::GenericOp::create(rewriter, loc, /*resultTypes=*/TypeRange{},
+                               insValues, blockShape, tileShape);
 
     IRMapping bodyMapping;
     initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
@@ -146,7 +161,7 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
 
     auto [blockShape, tileShape] = getBlockAndTileShapes(tensorTy, encoding);
 
-    SmallVector<Value> ins = {srcs[0]};
+    SmallVector<TiledInput> ins = {TiledInput{srcs[0], tileShape}};
     SmallVector<Type> resultTypes(reduceOp.getResultTypes().begin(),
                                   reduceOp.getResultTypes().end());
     if (srcUsedElsewhere)
@@ -154,7 +169,9 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
 
     LDBG("Creating reduction generic op, result types: " << resultTypes.size());
 
-    auto generic = cpu::GenericOp::create(rewriter, loc, resultTypes, ins,
+    SmallVector<Value> insValues =
+        llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
+    auto generic = cpu::GenericOp::create(rewriter, loc, resultTypes, insValues,
                                           blockShape, tileShape);
 
     IRMapping bodyMapping;
@@ -310,31 +327,208 @@ struct WrapKLoopWithDotOp : public mlir::OpRewritePattern<scf::ForOp> {
     // currently tiled.
     auto [blockShape, tileShape] = getBlockAndTileShapes(resultTy, encoding);
 
-    // Collect all values the for loop captures from outside its scope.
-    //   1. The forOp's explicit operands (lb, ub, step, init_args).
-    //   2. Free variables: values used by ops inside the body that are
-    //      defined outside the for op (implicit captures).
-    auto isDefinedInsideForOp = [&](Value v) -> bool {
-      if (auto blockArg = dyn_cast<BlockArgument>(v))
-        return forOp->isAncestor(blockArg.getOwner()->getParentOp());
-      return forOp->isAncestor(v.getDefiningOp());
+    auto aTy = cast<RankedTensorType>(dotOp.getA().getType());
+    assert(aTy.getRank() == 2 && "only 2D dot op supported");
+    int32_t kSize = (int32_t)aTy.getShape()[1];
+
+    SmallVector<int32_t> aTileShape = {tileShape[0], kSize};
+    SmallVector<int32_t> bTileShape = {kSize, tileShape[1]};
+
+    struct OperandChain {
+      SetVector<Operation *> body;
+      SmallVector<TiledInput> ins;
     };
 
-    SetVector<Value> capturedSet;
-    for (Value v : forOp.getOperands())
-      capturedSet.insert(v);
-    forOp.getBody()->walk([&](Operation *innerOp) {
-      for (Value operand : innerOp->getOperands())
-        if (!isDefinedInsideForOp(operand))
-          capturedSet.insert(operand);
-    });
-    SmallVector<Value> ins(capturedSet.begin(), capturedSet.end());
+    // Walk backward from rootOp (inside forOp's body) via getBackwardSlice.
+    // Populates:
+    //   body   — ops strictly inside forOp that are in this chain
+    //   ins — values defined outside forOp consumed by this chain,
+    //               including iter_arg init values traced across the boundary
+    unsigned numIVs = forOp.getNumInductionVars();
+    auto buildChain = [&](Operation *rootOp,
+                          ArrayRef<int32_t> shape) -> OperandChain {
+      OperandChain chain;
+
+      BackwardSliceOptions opts;
+      opts.omitBlockArguments = true;
+      opts.filter = [&](Operation *op) {
+        return op != forOp && forOp->isAncestor(op);
+      };
+      (void)getBackwardSlice(rootOp, &chain.body, opts);
+      chain.body.insert(rootOp); // getBackwardSlice excludes the root itself
+
+      for (Operation *op : chain.body) {
+        for (Value operand : op->getOperands()) {
+          if (auto barg = dyn_cast<BlockArgument>(operand)) {
+            if (barg.getOwner() != forOp.getBody())
+              continue;
+            if (barg.getArgNumber() < numIVs)
+              continue; // induction variable — defined by the loop, not
+                        // external
+            // iter_arg: cross the boundary to its init value
+            Value initVal = forOp.getInitArgs()[barg.getArgNumber() - numIVs];
+            bool isTensor = isa<RankedTensorType>(initVal.getType());
+            chain.ins.push_back({initVal, isTensor ? SmallVector<int32_t>(shape)
+                                                   : SmallVector<int32_t>{}});
+          } else if (!forOp->isAncestor(operand.getDefiningOp())) {
+            bool isTensor = isa<RankedTensorType>(operand.getType());
+            chain.ins.push_back({operand, isTensor ? SmallVector<int32_t>(shape)
+                                                   : SmallVector<int32_t>{}});
+          }
+        }
+      }
+      return chain;
+    };
+
+    // dotOp.getA() and getB() are results of loads inside the for body.
+    // dotOp.getC() is an iter_arg (block argument) — no chain needed, we
+    // reconstruct the zero accumulator at tile size inside the generic body.
+    OperandChain aChain = buildChain(dotOp.getA().getDefiningOp(), aTileShape);
+    OperandChain bChain = buildChain(dotOp.getB().getDefiningOp(), bTileShape);
+
+    auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    for (auto [iterArgIdx, offset] : info->ptrArgs) {
+      Operation *addPtrOp =
+          yieldOp.getOperands()[iterArgIdx].getDefiningOp<triton::AddPtrOp>();
+      assert(addPtrOp && "expected tt::add_ptr");
+      // determine which chain owns this ptr arg by checking aChain's ins
+      const auto iterArgIdx_ =
+          iterArgIdx; // captured structured bindings workaround
+      bool isAChain = llvm::any_of(aChain.ins, [&](const TiledInput &ti) {
+        return ti.value == forOp.getInitArgs()[iterArgIdx_];
+      });
+      OperandChain &chain = isAChain ? aChain : bChain;
+      ArrayRef<int32_t> shape = isAChain ? aTileShape : bTileShape;
+
+      // pull in the addptr and its offset operand chain
+      BackwardSliceOptions opts;
+      opts.omitBlockArguments = true;
+      opts.filter = [&](Operation *op) {
+        return op != forOp && forOp->isAncestor(op);
+      };
+      (void)getBackwardSlice(addPtrOp, &chain.body, opts);
+      chain.body.insert(addPtrOp);
+      // offset may be external
+      if (!forOp->isAncestor(offset.getDefiningOp()))
+        chain.ins.push_back({offset, {}});
+    }
+
+    // Build ins: for loop bounds (scalars, needed to reconstruct the inner
+    // scf.for) followed by A-chain then B-chain ins.
+    SmallVector<TiledInput> ins;
+    ins.push_back({forOp.getLowerBound(), {}});
+    ins.push_back({forOp.getUpperBound(), {}});
+    ins.push_back({forOp.getStep(), {}});
+    for (auto &inValue : aChain.ins)
+      ins.push_back(inValue);
+    for (auto &inValue : bChain.ins)
+      ins.push_back(inValue);
+
+    SmallVector<Value> insValues =
+        llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
 
     auto generic = cpu::GenericOp::create(rewriter, loc, TypeRange{resultTy},
-                                          ins, blockShape, tileShape);
+                                          insValues, blockShape, tileShape);
 
-    llvm::errs() << "generic: " << generic << "\n";
-    assert(false && "TODO");
+    IRMapping bodyMapping;
+    initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
+
+    Block *body = &generic.getBody().front();
+    unsigned argIdx = generic.getNumInductionVars();
+
+    for (Value scalar :
+         {forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep()})
+      bodyMapping.map(scalar, body->getArgument(argIdx++));
+
+    IRMapping aMapping, bMapping;
+    for (auto &ti : aChain.ins)
+      aMapping.map(ti.value, body->getArgument(argIdx++));
+    for (auto &ti : bChain.ins)
+      bMapping.map(ti.value, body->getArgument(argIdx++));
+
+    rewriter.setInsertionPointToStart(body);
+
+    // TODO: what if C is not loop carried?
+    // Zero-splat C at tile size
+    auto cInitConst = forOp.getInitArgs()[info->cIterArgIdx]
+                          .getDefiningOp<arith::ConstantOp>();
+    auto cDense = cast<DenseElementsAttr>(cInitConst.getValue());
+    auto cTileTy =
+        cast<RankedTensorType>(updateTensorType(resultTy, tileShape));
+    Value cTileInit = arith::ConstantOp::create(
+        rewriter, loc,
+        DenseElementsAttr::get(cTileTy,
+                               *cDense.getValues<Attribute>().begin()));
+
+    // Assemble iter_args for inner for: same slots as original
+    SmallVector<Value> innerInitArgs(forOp.getInitArgs().size());
+    innerInitArgs[info->cIterArgIdx] = cTileInit;
+    for (auto [iterArgIdx, _] : info->ptrArgs) {
+      Value origInit = forOp.getInitArgs()[iterArgIdx];
+      // init value lands in whichever chain owns it
+      innerInitArgs[iterArgIdx] = aMapping.contains(origInit)
+                                      ? aMapping.lookup(origInit)
+                                      : bMapping.lookup(origInit);
+    }
+
+    auto innerFor = scf::ForOp::create(
+        rewriter, loc, bodyMapping.lookup(forOp.getLowerBound()),
+        bodyMapping.lookup(forOp.getUpperBound()),
+        bodyMapping.lookup(forOp.getStep()), innerInitArgs);
+    rewriter.setInsertionPointToStart(innerFor.getBody());
+
+    // TODO: lambda-ify all this
+    // Remap original IV and iter_args to inner for's block args
+    auto remapIterArgs = [&](IRMapping &m) {
+      m.map(forOp.getInductionVar(), innerFor.getInductionVar());
+      for (unsigned i = 0; i < forOp.getInitArgs().size(); ++i)
+        m.map(forOp.getBody()->getArgument(numIVs + i),
+              innerFor.getBody()->getArgument(numIVs + i));
+    };
+
+    remapIterArgs(aMapping);
+    for (Operation *op : aChain.body) {
+      Operation *cloned = rewriter.clone(*op, aMapping);
+      for (auto [orig, res] : llvm::zip(op->getResults(), cloned->getResults()))
+        res.setType(updateTensorType(orig.getType(), aTileShape));
+      aMapping.map(op->getResults(), cloned->getResults());
+    }
+
+    remapIterArgs(bMapping);
+    for (Operation *op : bChain.body) {
+      Operation *cloned = rewriter.clone(*op, bMapping);
+      for (auto [orig, res] : llvm::zip(op->getResults(), cloned->getResults()))
+        res.setType(updateTensorType(orig.getType(), bTileShape));
+      bMapping.map(op->getResults(), cloned->getResults());
+    }
+
+    bodyMapping.map(dotOp.getA(), aMapping.lookup(dotOp.getA()));
+    bodyMapping.map(dotOp.getB(), bMapping.lookup(dotOp.getB()));
+    bodyMapping.map(dotOp.getC(), innerFor.getBody()->getArgument(
+                                      numIVs + info->cIterArgIdx));
+    Operation *clonedDot = rewriter.clone(*dotOp, bodyMapping);
+    clonedDot->getResult(0).setType(updateTensorType(resultTy, tileShape));
+
+    auto origYield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    SmallVector<Value> yieldVals(forOp.getInitArgs().size());
+    yieldVals[info->cIterArgIdx] = clonedDot->getResult(0);
+    for (auto [iterArgIdx, _] : info->ptrArgs) {
+      Value origYieldVal = origYield.getOperands()[iterArgIdx];
+      // look up the cloned addptr in whichever chain owns it
+      yieldVals[iterArgIdx] = aMapping.contains(origYieldVal)
+                                  ? aMapping.lookup(origYieldVal)
+                                  : bMapping.lookup(origYieldVal);
+    }
+    scf::YieldOp::create(rewriter, loc, yieldVals);
+
+    rewriter.setInsertionPointAfter(innerFor);
+    cpu::YieldOp::create(rewriter, loc,
+                         ValueRange{innerFor.getResult(info->cIterArgIdx)});
+
+    rewriter.replaceAllUsesWith(forOp.getResult(info->cIterArgIdx),
+                                generic.getResult(0));
+    rewriter.eraseOp(forOp);
+    return success();
   }
 };
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -744,6 +744,7 @@ struct TritonCPUTileAndFusePass
     patterns.add<WrapStores>(context, benefitDefault);
     patterns.add<WrapReduceOp>(context, benefitDefault);
     patterns.add<WrapKLoopWithDotOp>(context, benefitDefault);
+    // TODO: wrap convert layout as anchor op?
 
     if (applyPatternsGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -653,12 +653,17 @@ struct FuseMakeRangeIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
       // 1. clone (make range has no operands)
       rewriter.setInsertionPointToStart(body);
 
-      auto resultType = makeRangeOp.getResult().getType();
+      auto resultType =
+          cast<RankedTensorType>(makeRangeOp.getResult().getType());
       auto newResultType = updateTensorType(resultType, tileShape);
+      // TODO: get the right slice chunk offset
+      auto sliceEncodingAttr =
+          dyn_cast<triton::gpu::SliceEncodingAttr>(resultType.getEncoding());
+      unsigned dim = sliceEncodingAttr ? sliceEncodingAttr.getDim() : 0;
       cpu::MakeDynamicRangeOp makeDynamicRangeOp =
           triton::cpu::MakeDynamicRangeOp::create(
               rewriter, makeRangeOp.getLoc(), newResultType,
-              genericOp.getChunkOffset());
+              genericOp.getTileOffset(dim));
 
       // 3. update existing uses
       blockArg.replaceAllUsesWith(makeDynamicRangeOp.getResult());
@@ -728,6 +733,124 @@ struct FuseConstantIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
   }
 };
 
+struct FuseBroadcastIntoGeneric
+    : public mlir::OpRewritePattern<cpu::GenericOp> {
+  using OpRewritePattern<cpu::GenericOp>::OpRewritePattern;
+
+  LogicalResult
+  matchAndRewrite(cpu::GenericOp genericOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    Block *body = &genericOp.getBody().front();
+    unsigned numIV = genericOp.getNumInductionVars();
+
+    for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
+      Operation *op = insVal.getDefiningOp();
+      if (!op)
+        continue;
+
+      auto broadcastOp = dyn_cast<triton::BroadcastOp>(op);
+      if (!broadcastOp)
+        continue;
+
+      BlockArgument blockArg = body->getArgument(numIV + i);
+      auto tiledType = cast<RankedTensorType>(blockArg.getType());
+      SmallVector<int32_t> tileShape(tiledType.getShape());
+      SmallVector<Value> newIns(genericOp.getIns());
+
+      // broadcast source operand: only tile the non-broadcast dim
+      RankedTensorType sourceTensorType =
+          cast<RankedTensorType>(broadcastOp.getSrc().getType());
+      SmallVector<int32_t> sourceTileShape = llvm::to_vector(
+          llvm::map_range(llvm::zip(sourceTensorType.getShape(), tileShape),
+                          [](auto pair) -> int32_t {
+                            auto [s, t] = pair;
+                            return s == 1 ? s : t;
+                          }));
+
+      llvm::errs() << "broadcast op: " << broadcastOp << "\n";
+      llvm::errs() << "broadcast source type: " << sourceTensorType << "\n";
+      llvm::errs() << "tileShape: ";
+      for (auto t : tileShape)
+        llvm::errs() << t << " ";
+      llvm::errs() << "\n";
+      llvm::errs() << "sourceTileShape: ";
+      for (auto st : sourceTileShape)
+        llvm::errs() << st << " ";
+      llvm::errs() << "\n";
+
+      Type blockArgType = updateTensorType(sourceTensorType, sourceTileShape);
+      llvm::errs() << "block arg type: " << blockArgType << "\n";
+
+      IRMapping mapping;
+      // 1. map src operand to block args
+      newIns.push_back(broadcastOp.getSrc());
+      mapping.map(
+          broadcastOp.getSrc(),
+          body->addArgument(blockArgType, broadcastOp.getSrc().getLoc()));
+
+      // 2. clone the broadcast
+      rewriter.setInsertionPointToStart(body);
+      Operation *newBroadcast = rewriter.clone(*op, mapping);
+      Type origResultType = broadcastOp.getResult().getType();
+      newBroadcast->getResult(0).setType(
+          updateTensorType(origResultType, tileShape));
+
+      // 3. replace block arg and clean up
+      blockArg.replaceAllUsesWith(newBroadcast->getResult(0));
+      body->eraseArgument(numIV + i);
+      newIns.erase(newIns.begin() + i);
+
+      rewriter.modifyOpInPlace(
+          genericOp, [&]() { genericOp.getInsMutable().assign(newIns); });
+
+      return success();
+    }
+
+    return failure();
+  }
+};
+
+struct FuseExpandDimsIntoGeneric
+    : public mlir::OpRewritePattern<cpu::GenericOp> {
+  using OpRewritePattern<cpu::GenericOp>::OpRewritePattern;
+
+  LogicalResult
+  matchAndRewrite(cpu::GenericOp genericOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    Block *body = &genericOp.getBody().front();
+    unsigned numIV = genericOp.getNumInductionVars();
+
+    for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
+      Operation *op = insVal.getDefiningOp();
+      if (!op)
+        continue;
+
+      auto expandDimsOp = dyn_cast<triton::ExpandDimsOp>(op);
+      if (!expandDimsOp)
+        continue;
+
+      BlockArgument blockArg = body->getArgument(numIV + i);
+      auto tiledType = cast<RankedTensorType>(blockArg.getType());
+      SmallVector<int32_t> tileShape(tiledType.getShape());
+      SmallVector<Value> newIns(genericOp.getIns());
+
+      llvm::errs() << "tile shape: ";
+      for (auto s : tileShape)
+        llvm::errs() << s << " ";
+      llvm::errs() << "\n";
+
+      llvm::errs() << "expand dims = " << expandDimsOp << "\n";
+      return failure();
+
+      assert(false && "TODO");
+
+      return success();
+    }
+
+    return failure();
+  }
+};
+
 } // namespace
 
 struct TritonCPUTileAndFusePass
@@ -754,6 +877,8 @@ struct TritonCPUTileAndFusePass
     RewritePatternSet fusePatterns(context);
 
     fusePatterns.add<FuseElementwiseIntoGeneric>(context, benefitDefault);
+    fusePatterns.add<FuseBroadcastIntoGeneric>(context, benefitDefault);
+    fusePatterns.add<FuseExpandDimsIntoGeneric>(context, benefitDefault);
     fusePatterns.add<FuseMakeRangeIntoGeneric>(context, benefitDefault);
     fusePatterns.add<FuseConstantIntoGeneric>(context, benefitDefault);
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -26,10 +26,15 @@ static Type updateTensorType(Type t, ArrayRef<int32_t> tileShape) {
   auto tensorType = dyn_cast<RankedTensorType>(t);
   if (!tensorType)
     return t;
-  return RankedTensorType::get(
-      llvm::to_vector(
-          llvm::map_range(tileShape, [](int32_t s) { return int64_t(s); })),
-      tensorType.getElementType(), tensorType.getEncoding());
+  assert(tensorType.getRank() == tileShape.size() &&
+         "expected tensor type and tile shape to have same rank");
+  SmallVector<int64_t> newShape;
+  // for broadcast/expanded dims (size 1) do not use the tile shape
+  for (auto [s, tile] : llvm::zip(tensorType.getShape(), tileShape))
+    newShape.push_back(std::min(s, (int64_t)tile));
+
+  return RankedTensorType::get(newShape, tensorType.getElementType(),
+                               tensorType.getEncoding());
 }
 
 // Extract blockShape (full tensor shape) and tileShape (sizePerThread) from
@@ -767,26 +772,13 @@ struct FuseBroadcastIntoGeneric
                             return s == 1 ? s : t;
                           }));
 
-      llvm::errs() << "broadcast op: " << broadcastOp << "\n";
-      llvm::errs() << "broadcast source type: " << sourceTensorType << "\n";
-      llvm::errs() << "tileShape: ";
-      for (auto t : tileShape)
-        llvm::errs() << t << " ";
-      llvm::errs() << "\n";
-      llvm::errs() << "sourceTileShape: ";
-      for (auto st : sourceTileShape)
-        llvm::errs() << st << " ";
-      llvm::errs() << "\n";
-
-      Type blockArgType = updateTensorType(sourceTensorType, sourceTileShape);
-      llvm::errs() << "block arg type: " << blockArgType << "\n";
-
       IRMapping mapping;
       // 1. map src operand to block args
       newIns.push_back(broadcastOp.getSrc());
       mapping.map(
           broadcastOp.getSrc(),
-          body->addArgument(blockArgType, broadcastOp.getSrc().getLoc()));
+          body->addArgument(updateTensorType(sourceTensorType, sourceTileShape),
+                            broadcastOp.getSrc().getLoc()));
 
       // 2. clone the broadcast
       rewriter.setInsertionPointToStart(body);
@@ -834,15 +826,40 @@ struct FuseExpandDimsIntoGeneric
       SmallVector<int32_t> tileShape(tiledType.getShape());
       SmallVector<Value> newIns(genericOp.getIns());
 
-      llvm::errs() << "tile shape: ";
-      for (auto s : tileShape)
-        llvm::errs() << s << " ";
-      llvm::errs() << "\n";
+      unsigned axis = expandDimsOp.getAxis();
+      assert(tileShape[axis] == 1 &&
+             "expected expand dims axis tile shape to be 1");
 
-      llvm::errs() << "expand dims = " << expandDimsOp << "\n";
-      return failure();
+      SmallVector<int32_t> sourceTileShape;
+      for (auto [j, t] : llvm::enumerate(tileShape)) {
+        if (j == axis)
+          continue;
+        sourceTileShape.push_back(t);
+      }
 
-      assert(false && "TODO");
+      RankedTensorType sourceTensorType =
+          cast<RankedTensorType>(expandDimsOp.getSrc().getType());
+      IRMapping mapping;
+      // 1. map src operand to block args
+      newIns.push_back(expandDimsOp.getSrc());
+      mapping.map(
+          expandDimsOp.getSrc(),
+          body->addArgument(updateTensorType(sourceTensorType, sourceTileShape),
+                            expandDimsOp.getSrc().getLoc()));
+
+      // 2. clone expand dims
+      rewriter.setInsertionPointToStart(body);
+      Operation *newExpandDims = rewriter.clone(*op, mapping);
+      Type origResultType = expandDimsOp.getResult().getType();
+      newExpandDims->getResult(0).setType(
+          updateTensorType(origResultType, tileShape));
+
+      blockArg.replaceAllUsesWith(newExpandDims->getResult(0));
+      body->eraseArgument(numIV + i);
+      newIns.erase(newIns.begin() + i);
+
+      rewriter.modifyOpInPlace(
+          genericOp, [&]() { genericOp.getInsMutable().assign(newIns); });
 
       return success();
     }

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -345,31 +345,36 @@ struct WrapKLoopWithDotOp : public mlir::OpRewritePattern<scf::ForOp> {
     //   ins — values defined outside forOp consumed by this chain,
     //               including iter_arg init values traced across the boundary
     unsigned numIVs = forOp.getNumInductionVars();
-    auto buildChain = [&](Operation *rootOp,
-                          ArrayRef<int32_t> shape) -> OperandChain {
-      OperandChain chain;
 
-      BackwardSliceOptions opts;
-      opts.omitBlockArguments = true;
-      opts.filter = [&](Operation *op) {
-        return op != forOp && forOp->isAncestor(op);
-      };
-      (void)getBackwardSlice(rootOp, &chain.body, opts);
-      chain.body.insert(rootOp); // getBackwardSlice excludes the root itself
+    BackwardSliceOptions sliceOpts;
+    sliceOpts.omitBlockArguments = true;
+    sliceOpts.filter = [&](Operation *op) {
+      return op != forOp && forOp->isAncestor(op);
+    };
 
-      for (Operation *op : chain.body) {
+    // Scan `ops` for operands defined outside forOp and append them to
+    // `chain.ins`. Crosses iter_arg boundaries to their init values; treats
+    // other external block args (e.g. function arguments) as plain externals.
+    auto collectExternals = [&](ArrayRef<Operation *> ops, OperandChain &chain,
+                                ArrayRef<int32_t> shape) {
+      for (Operation *op : ops) {
         for (Value operand : op->getOperands()) {
           if (auto barg = dyn_cast<BlockArgument>(operand)) {
-            if (barg.getOwner() != forOp.getBody())
-              continue;
-            if (barg.getArgNumber() < numIVs)
-              continue; // induction variable — defined by the loop, not
-                        // external
-            // iter_arg: cross the boundary to its init value
-            Value initVal = forOp.getInitArgs()[barg.getArgNumber() - numIVs];
-            bool isTensor = isa<RankedTensorType>(initVal.getType());
-            chain.ins.push_back({initVal, isTensor ? SmallVector<int32_t>(shape)
-                                                   : SmallVector<int32_t>{}});
+            if (barg.getOwner() == forOp.getBody()) {
+              if (barg.getArgNumber() < numIVs)
+                continue; // induction variable
+              Value initVal = forOp.getInitArgs()[barg.getArgNumber() - numIVs];
+              bool isTensor = isa<RankedTensorType>(initVal.getType());
+              chain.ins.push_back({initVal, isTensor
+                                                ? SmallVector<int32_t>(shape)
+                                                : SmallVector<int32_t>{}});
+            } else {
+              // external block arg (e.g. function argument)
+              bool isTensor = isa<RankedTensorType>(operand.getType());
+              chain.ins.push_back({operand, isTensor
+                                                ? SmallVector<int32_t>(shape)
+                                                : SmallVector<int32_t>{}});
+            }
           } else if (!forOp->isAncestor(operand.getDefiningOp())) {
             bool isTensor = isa<RankedTensorType>(operand.getType());
             chain.ins.push_back({operand, isTensor ? SmallVector<int32_t>(shape)
@@ -377,6 +382,14 @@ struct WrapKLoopWithDotOp : public mlir::OpRewritePattern<scf::ForOp> {
           }
         }
       }
+    };
+
+    auto buildChain = [&](Operation *rootOp,
+                          ArrayRef<int32_t> shape) -> OperandChain {
+      OperandChain chain;
+      (void)getBackwardSlice(rootOp, &chain.body, sliceOpts);
+      chain.body.insert(rootOp); // getBackwardSlice excludes the root itself
+      collectExternals(chain.body.getArrayRef(), chain, shape);
       return chain;
     };
 
@@ -408,9 +421,7 @@ struct WrapKLoopWithDotOp : public mlir::OpRewritePattern<scf::ForOp> {
       };
       (void)getBackwardSlice(addPtrOp, &chain.body, opts);
       chain.body.insert(addPtrOp);
-      // offset may be external
-      if (!forOp->isAncestor(offset.getDefiningOp()))
-        chain.ins.push_back({offset, {}});
+      collectExternals(chain.body.getArrayRef(), chain, shape);
     }
 
     // Build ins: for loop bounds (scalars, needed to reconstruct the inner

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -559,6 +559,62 @@ struct WrapKLoopWithDotOp : public mlir::OpRewritePattern<scf::ForOp> {
   }
 };
 
+struct WrapConvertLayoutOp
+    : mlir::OpRewritePattern<triton::gpu::ConvertLayoutOp> {
+  using OpRewritePattern<triton::gpu::ConvertLayoutOp>::OpRewritePattern;
+
+  LogicalResult
+  matchAndRewrite(triton::gpu::ConvertLayoutOp cvtOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto loc = cvtOp.getLoc();
+
+    if (cvtOp->getParentOfType<cpu::GenericOp>())
+      return failure();
+
+    auto operand = cvtOp.getSrc();
+
+    auto tensorTy = cast<RankedTensorType>(operand.getType());
+    auto encoding = dyn_cast<gpu::BlockedEncodingAttr>(tensorTy.getEncoding());
+    if (!encoding)
+      return failure();
+
+    // only wrap blocked->blocked conversions
+    auto convertedTensorTy =
+        cast<RankedTensorType>(cvtOp.getResult().getType());
+    if (!isa<triton::gpu::BlockedEncodingAttr>(convertedTensorTy.getEncoding()))
+      return failure();
+
+    // Note: this uses the source tensor ty to determine the tile shape. if we
+    // tile over the source, we should be able to write to any location in the
+    // output
+    auto [blockShape, tileShape] = getBlockAndTileShapes(tensorTy, encoding);
+
+    // but, overwrite the tileshape to match the block shape (i.e. just generate
+    // a single tile generic for now)
+    tileShape = blockShape;
+
+    SmallVector<TiledInput> ins;
+    for (auto value : cvtOp->getOperands()) {
+      ins.push_back(TiledInput{value, tileShape});
+    }
+    SmallVector<Value> insValues =
+        llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
+
+    auto generic = cpu::GenericOp::create(
+        rewriter, loc, /*resultTypes=*/TypeRange{convertedTensorTy}, insValues,
+        blockShape, tileShape);
+
+    IRMapping bodyMapping;
+    initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
+
+    auto newCvt = rewriter.clone(*cvtOp, bodyMapping);
+    cpu::YieldOp::create(rewriter, loc, newCvt->getResults());
+
+    rewriter.replaceOp(cvtOp, generic.getResults());
+    return success();
+  }
+};
+
 struct FuseElementwiseIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
   using OpRewritePattern<cpu::GenericOp>::OpRewritePattern;
 
@@ -881,10 +937,10 @@ struct TritonCPUTileAndFusePass
     constexpr int benefitDefault = 1;
 
     // Step 1: Create the generic ops
-    patterns.add<WrapStores>(context, benefitDefault);
-    patterns.add<WrapReduceOp>(context, benefitDefault);
-    patterns.add<WrapKLoopWithDotOp>(context, benefitDefault);
-    // TODO: wrap convert layout as anchor op?
+    patterns.add<WrapStores>(context, benefitDefault + 1);
+    patterns.add<WrapReduceOp>(context, benefitDefault + 1);
+    patterns.add<WrapKLoopWithDotOp>(context, benefitDefault + 1);
+    patterns.add<WrapConvertLayoutOp>(context, benefitDefault);
 
     if (applyPatternsGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -215,6 +215,129 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
   }
 };
 
+struct WrapKLoopWithDotOp : public mlir::OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+
+  struct KLoopDotInfo {
+    triton::DotOp dotOp;
+    unsigned cIterArgIdx;
+    SmallVector<std::pair<unsigned, Value>>
+        ptrArgs; // loop carried ptr values for A and B dot operands
+  };
+
+  static std::optional<KLoopDotInfo> matchKLoopWithDot(scf::ForOp forOp) {
+    if (forOp->getParentOfType<cpu::GenericOp>())
+      return std::nullopt;
+
+    triton::DotOp dotOp;
+    for (auto &op : *forOp.getBody()) {
+      if (auto d = dyn_cast<triton::DotOp>(&op)) {
+        if (dotOp)
+          return std::nullopt; // TODO: handle multiple dots?
+        dotOp = d;
+      }
+    }
+    if (!dotOp)
+      return std::nullopt;
+
+    // Dot result must have BlockedEncoding so we can derive
+    // blockShape/vectorShape.
+    auto resultTy = dyn_cast<RankedTensorType>(dotOp.getType());
+    if (!resultTy || !isa<gpu::BlockedEncodingAttr>(resultTy.getEncoding()))
+      return std::nullopt;
+
+    // C operand must be an iter_arg of this loop (not a constant or external
+    // value).
+    auto cArg = dyn_cast<BlockArgument>(dotOp.getC());
+    if (!cArg || cArg.getOwner() != forOp.getBody())
+      return std::nullopt;
+    unsigned numIVs = forOp.getNumInductionVars();
+    unsigned cArgNum = cArg.getArgNumber();
+    if (cArgNum < numIVs)
+      return std::nullopt;
+    unsigned cIterArgIdx = cArgNum - numIVs;
+
+    // C's init value must be a zero-splat constant — we reconstruct it at tile
+    // size inside the generic body.
+    auto cInitOp =
+        forOp.getInitArgs()[cIterArgIdx].getDefiningOp<arith::ConstantOp>();
+    if (!cInitOp)
+      return std::nullopt;
+    auto dense = dyn_cast<DenseElementsAttr>(cInitOp.getValue());
+    if (!dense || !dense.isSplat())
+      return std::nullopt;
+    if (auto fp = dyn_cast<FloatAttr>(dense.getSplatValue<Attribute>()))
+      if (!fp.getValue().isZero())
+        return std::nullopt;
+
+    // The yield must carry the dot result back as the updated C value.
+    auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    if (yieldOp.getOperands()[cIterArgIdx] != dotOp.getResult())
+      return std::nullopt;
+
+    // Find pointer iter_args that are advanced by tt.addptr each iteration.
+    SmallVector<std::pair<unsigned, Value>> ptrArgs;
+    for (unsigned i = 0, e = forOp.getInitArgs().size(); i < e; ++i) {
+      if (i == cIterArgIdx)
+        continue;
+      Value iterArgVal = forOp.getBody()->getArgument(numIVs + i);
+      auto addPtrOp =
+          yieldOp.getOperands()[i].getDefiningOp<triton::AddPtrOp>();
+      if (!addPtrOp || addPtrOp.getPtr() != iterArgVal)
+        continue;
+      ptrArgs.push_back({i, addPtrOp.getOffset()});
+    }
+    if (ptrArgs.empty())
+      return std::nullopt;
+
+    return KLoopDotInfo{dotOp, cIterArgIdx, ptrArgs};
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(scf::ForOp forOp,
+                  mlir::PatternRewriter &rewriter) const override {
+
+    auto info = matchKLoopWithDot(forOp);
+    if (!info)
+      return failure();
+
+    Location loc = forOp.getLoc();
+    triton::DotOp dotOp = info->dotOp;
+    auto resultTy = cast<RankedTensorType>(dotOp.getType());
+    auto encoding = cast<gpu::BlockedEncodingAttr>(resultTy.getEncoding());
+
+    // use the MxN (result) shape for block/tile shapes. The K loop is not
+    // currently tiled.
+    auto [blockShape, tileShape] = getBlockAndTileShapes(resultTy, encoding);
+
+    // Collect all values the for loop captures from outside its scope.
+    //   1. The forOp's explicit operands (lb, ub, step, init_args).
+    //   2. Free variables: values used by ops inside the body that are
+    //      defined outside the for op (implicit captures).
+    auto isDefinedInsideForOp = [&](Value v) -> bool {
+      if (auto blockArg = dyn_cast<BlockArgument>(v))
+        return forOp->isAncestor(blockArg.getOwner()->getParentOp());
+      return forOp->isAncestor(v.getDefiningOp());
+    };
+
+    SetVector<Value> capturedSet;
+    for (Value v : forOp.getOperands())
+      capturedSet.insert(v);
+    forOp.getBody()->walk([&](Operation *innerOp) {
+      for (Value operand : innerOp->getOperands())
+        if (!isDefinedInsideForOp(operand))
+          capturedSet.insert(operand);
+    });
+    SmallVector<Value> ins(capturedSet.begin(), capturedSet.end());
+
+    auto generic = cpu::GenericOp::create(rewriter, loc, TypeRange{resultTy},
+                                          ins, blockShape, tileShape);
+
+    llvm::errs() << "generic: " << generic << "\n";
+    assert(false && "TODO");
+  }
+};
+
 struct FuseElementwiseIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
   using OpRewritePattern<cpu::GenericOp>::OpRewritePattern;
 
@@ -404,6 +527,7 @@ struct TritonCPUTileAndFusePass
     // Step 1: Create the generic ops
     patterns.add<WrapStores>(context, benefitDefault);
     patterns.add<WrapReduceOp>(context, benefitDefault);
+    patterns.add<WrapKLoopWithDotOp>(context, benefitDefault);
 
     if (applyPatternsGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -357,6 +357,10 @@ struct WrapKLoopWithDotOp : public mlir::OpRewritePattern<scf::ForOp> {
     // other external block args (e.g. function arguments) as plain externals.
     auto collectExternals = [&](ArrayRef<Operation *> ops, OperandChain &chain,
                                 ArrayRef<int32_t> shape) {
+      DenseSet<Value> seen;
+      for (auto &ti : chain.ins) // pre-populate from prior calls
+        seen.insert(ti.value);
+
       for (Operation *op : ops) {
         for (Value operand : op->getOperands()) {
           if (auto barg = dyn_cast<BlockArgument>(operand)) {
@@ -364,21 +368,28 @@ struct WrapKLoopWithDotOp : public mlir::OpRewritePattern<scf::ForOp> {
               if (barg.getArgNumber() < numIVs)
                 continue; // induction variable
               Value initVal = forOp.getInitArgs()[barg.getArgNumber() - numIVs];
-              bool isTensor = isa<RankedTensorType>(initVal.getType());
-              chain.ins.push_back({initVal, isTensor
-                                                ? SmallVector<int32_t>(shape)
-                                                : SmallVector<int32_t>{}});
+              if (seen.insert(initVal).second) {
+                bool isTensor = isa<RankedTensorType>(initVal.getType());
+                chain.ins.push_back({initVal, isTensor
+                                                  ? SmallVector<int32_t>(shape)
+                                                  : SmallVector<int32_t>{}});
+              }
             } else {
               // external block arg (e.g. function argument)
+              if (seen.insert(operand).second) {
+                bool isTensor = isa<RankedTensorType>(operand.getType());
+                chain.ins.push_back({operand, isTensor
+                                                  ? SmallVector<int32_t>(shape)
+                                                  : SmallVector<int32_t>{}});
+              }
+            }
+          } else if (!forOp->isAncestor(operand.getDefiningOp())) {
+            if (seen.insert(operand).second) {
               bool isTensor = isa<RankedTensorType>(operand.getType());
               chain.ins.push_back({operand, isTensor
                                                 ? SmallVector<int32_t>(shape)
                                                 : SmallVector<int32_t>{}});
             }
-          } else if (!forOp->isAncestor(operand.getDefiningOp())) {
-            bool isTensor = isa<RankedTensorType>(operand.getType());
-            chain.ins.push_back({operand, isTensor ? SmallVector<int32_t>(shape)
-                                                   : SmallVector<int32_t>{}});
           }
         }
       }

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -67,8 +67,8 @@ static Block *initGenericBody(OpBuilder &rewriter, cpu::GenericOp generic,
                       generic.getLoc()); // tile offset per vector shape dim
 
   for (auto pair : ins) {
-    auto [v, tileShape] = pair;
-    Type argTy = updateTensorType(v.getType(), tileShape);
+    auto [v, inputTileShape] = pair;
+    Type argTy = updateTensorType(v.getType(), inputTileShape);
     mapping.map(v, body->addArgument(argTy, v.getLoc()));
   }
   rewriter.setInsertionPointToStart(body);

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -5,6 +5,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
 #include "PatternTritonGPUOpToLLVM.h"
+#include <functional>
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -237,14 +238,25 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         tileArgs.push_back(UnrealizedConversionCastOp::create(
                                rewriter, loc, origArg.getType(), tileStruct)
                                .getResult(0));
+      } else if (isa<PointerType>(origArg.getType())) {
+        // we might have a tt.ptr hiding in an unrealized conversion cast due to
+        // late conversion of generic op block arguments. Use unrealized
+        // conversion cast which will be folded away later
+        if (origArg.getType() != llvmArg.getType()) {
+          tileArgs.push_back(
+              UnrealizedConversionCastOp::create(
+                  rewriter, loc, llvmArg.getType(), op.getOperand(opIdx))
+                  .getResult(0));
+        } else {
+          tileArgs.push_back(op.getOperand(opIdx));
+        }
       } else {
         assert(!isa<RankedTensorType>(origArg.getType()) &&
-               "tensor types from non-generic ops are not allowed in the "
-               "dynamic generic tile loop path");
-        assert(isa<PointerType>(origArg.getType()) ||
-               origArg.getType() == llvmArg.getType() &&
-                   "expected non-tensor arguments to be unchanged by type "
-                   "conversion");
+               "tensor types are not allowed in compile-time generated "
+               "generic tile loops");
+        assert(origArg.getType() == llvmArg.getType() &&
+               "expected non-tensor arguments to be unchanged by type "
+               "conversion");
         tileArgs.push_back(op.getOperand(opIdx));
       }
     }
@@ -256,7 +268,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
   // only one tile and loop overhead is unnecessary.
   void emitUnrolled(cpu::GenericOp op, OpAdaptor adaptor,
                     ConversionPatternRewriter &rewriter, unsigned numChunks,
-                    unsigned vectorSize, Value &result,
+                    unsigned vectorSize, ArrayRef<int32_t> blockShape,
+                    ArrayRef<int32_t> tileShape, Value &result,
                     ArrayRef<Value> tensorAccPtrs,
                     ArrayRef<Type> tensorElemTys) const {
     Location loc = op.getLoc();
@@ -264,10 +277,21 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     for (unsigned i = 0; i < numChunks; ++i) {
       SmallVector<Value> chunkedArgs =
           buildStaticChunkedArgs(op, adaptor, rewriter, i, vectorSize);
-      Value chunkOffset = b.i32_val(i * vectorSize);
+
+      unsigned rank = blockShape.size();
+      SmallVector<Value> perDimOffsets(rank);
+      unsigned remaining = i;
+      for (int d = rank - 1; d >= 0; --d) {
+        unsigned nc = blockShape[d] / tileShape[d];
+        unsigned chunkIdx = remaining % nc;
+        perDimOffsets[d] = b.i32_val(chunkIdx * tileShape[d]);
+        remaining /= nc;
+      }
+
+      Value flatOffset = b.i32_val(i * vectorSize);
       auto tiles =
-          emitTileBody(op, rewriter, chunkedArgs, {chunkOffset}, result);
-      scatterTiles(rewriter, loc, tiles, chunkOffset, vectorSize, tensorAccPtrs,
+          emitTileBody(op, rewriter, chunkedArgs, perDimOffsets, result);
+      scatterTiles(rewriter, loc, tiles, flatOffset, vectorSize, tensorAccPtrs,
                    tensorElemTys);
     }
   }
@@ -404,6 +428,20 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     rewriter.inlineRegionBefore(bodyRegion, *afterBlock->getParent(),
                                 afterBlock->getIterator());
 
+    TypeConverter::SignatureConversion sigConv(bodyEntry->getNumArguments());
+    for (auto [idx, arg] : llvm::enumerate(bodyEntry->getArguments()))
+      sigConv.addInputs(idx, getTypeConverter()->convertType(arg.getType()));
+    bodyEntry = rewriter.applySignatureConversion(bodyEntry, sigConv,
+                                                  getTypeConverter());
+
+    // Branch from loopBody into the inlined region, passing induction vars then
+    // tile args as block arguments to match bodyEntry's argument list.
+    rewriter.setInsertionPointToEnd(loopBody);
+    SmallVector<Value> entryArgs;
+    entryArgs.append(tileOffsets.begin(), tileOffsets.end());
+    entryArgs.append(tileArgs.begin(), tileArgs.end());
+    LLVM::BrOp::create(rewriter, loc, entryArgs, bodyEntry);
+
     for (Block &block : llvm::make_range(bodyEntry->getIterator(),
                                          afterBlock->getIterator())) {
       auto yieldOp = dyn_cast<cpu::YieldOp>(block.getTerminator());
@@ -476,7 +514,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     for (Type resultTy :
          llvm::drop_begin(op.getResultTypes(), numCombinerBlocks)) {
       auto tensorTy = cast<RankedTensorType>(resultTy);
-      int64_t blockSize = blockShape[0];
+      int64_t blockSize = std::accumulate(blockShape.begin(), blockShape.end(),
+                                          0, std::multiplies<>());
       Type elemTy = getTypeConverter()->convertType(tensorTy.getElementType());
       tensorElemTys.push_back(elemTy);
 
@@ -525,10 +564,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     Value result;
     if (requiresTensorArgMaterialization || numChunks == 1) {
-      assert(blockShape.size() == 1 &&
-             "only support rank-1 generic tiles in unrolled path");
-      emitUnrolled(op, adaptor, rewriter, numChunks, vectorSize, result,
-                   tensorAccPtrs, tensorElemTys);
+      emitUnrolled(op, adaptor, rewriter, numChunks, vectorSize, blockShape,
+                   tileShape, result, tensorAccPtrs, tensorElemTys);
     } else if (hasReductions) {
       assert(blockShape.size() == 1 &&
              "only support rank-1 generic tiles in reductions path");

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -309,22 +309,22 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       SmallVector<Value> perDimOffsets(rank);
       unsigned remaining = i;
       LDBG("i = " << i);
+      // Body induction vars are ordered innermost-first (col, then row), so
+      // store offsets at rank-1-d to match that convention.
       for (int d = rank - 1; d >= 0; --d) {
         unsigned nc = blockShape[d] / tileShape[d];
         unsigned chunkIdx = remaining % nc;
-        LDBG("perDimOffsets[" << d << "] = " << chunkIdx << " * "
+        LDBG("perDimOffsets[" << rank - 1 - d << "] = " << chunkIdx << " * "
                               << tileShape[d] << " = "
                               << (chunkIdx * tileShape[d]));
-        perDimOffsets[d] = b.i32_val(chunkIdx * tileShape[d]);
+        perDimOffsets[rank - 1 - d] = b.i32_val(chunkIdx * tileShape[d]);
         remaining /= nc;
       }
 
       Value flatOffset = b.i32_val(i * vectorSize);
       LDBG("flatOffset = " << (i * vectorSize));
-      SmallVector<Value> reversedOffsets(perDimOffsets.rbegin(),
-                                         perDimOffsets.rend());
       auto tiles =
-          emitTileBody(op, rewriter, chunkedArgs, reversedOffsets, result);
+          emitTileBody(op, rewriter, chunkedArgs, perDimOffsets, result);
       scatterTiles(rewriter, loc, tiles, flatOffset, vectorSize, tensorAccPtrs,
                    tensorElemTys);
     }
@@ -435,7 +435,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     for (int d = rank - 1; d >= 0; --d) {
       unsigned nc = blockShape[d] / tileShape[d];
       Value chunkIdx = b.urem(remaining, b.i32_val(nc));
-      tileOffsets[d] = b.mul(chunkIdx, b.i32_val(tileShape[d]));
+      tileOffsets[rank - 1 - d] = b.mul(chunkIdx, b.i32_val(tileShape[d]));
       remaining = b.udiv(remaining, b.i32_val(nc));
     }
     // Flat offset for accumulator scatter (tile-major layout)

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -538,7 +538,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
          llvm::drop_begin(op.getResultTypes(), numCombinerBlocks)) {
       auto tensorTy = cast<RankedTensorType>(resultTy);
       int64_t blockSize = std::accumulate(blockShape.begin(), blockShape.end(),
-                                          0, std::multiplies<>());
+                                          1, std::multiplies<>());
       Type elemTy = getTypeConverter()->convertType(tensorTy.getElementType());
       tensorElemTys.push_back(elemTy);
 

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -58,7 +58,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     for (auto [opIdx, origArg, llvmArg] : llvm::enumerate(
              body->getArguments().drop_front(op.getNumInductionVars()),
              adaptor.getOperands())) {
-
+      LDBG("Chunk operand " << opIdx << " = " << origArg << " --> " << llvmArg);
       if (!isa<RankedTensorType>(origArg.getType())) {
         // forward constants and scalars without chunking
         assert(isa<PointerType>(origArg.getType()) ||
@@ -95,7 +95,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
         for (unsigned j = 0; j < vectorSize; ++j) {
           int64_t srcIndex = i * vectorSize + j;
-
+          LDBG("Read " << srcIndex);
           Value extractedElement =
               LLVM::ExtractValueOp::create(rewriter, loc, llvmArg, {srcIndex});
           chunk = LLVM::InsertValueOp::create(rewriter, loc, chunk,
@@ -297,6 +297,10 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                     ArrayRef<Type> tensorElemTys) const {
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    LDBG("Unrolling generic, cloning body for " << numChunks
+                                                << " loop iterations");
+
     for (unsigned i = 0; i < numChunks; ++i) {
       SmallVector<Value> chunkedArgs =
           buildStaticChunkedArgs(op, adaptor, rewriter, i, vectorSize);
@@ -304,16 +308,23 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       unsigned rank = blockShape.size();
       SmallVector<Value> perDimOffsets(rank);
       unsigned remaining = i;
+      LDBG("i = " << i);
       for (int d = rank - 1; d >= 0; --d) {
         unsigned nc = blockShape[d] / tileShape[d];
         unsigned chunkIdx = remaining % nc;
+        LDBG("perDimOffsets[" << d << "] = " << chunkIdx << " * "
+                              << tileShape[d] << " = "
+                              << (chunkIdx * tileShape[d]));
         perDimOffsets[d] = b.i32_val(chunkIdx * tileShape[d]);
         remaining /= nc;
       }
 
       Value flatOffset = b.i32_val(i * vectorSize);
+      LDBG("flatOffset = " << (i * vectorSize));
+      SmallVector<Value> reversedOffsets(perDimOffsets.rbegin(),
+                                         perDimOffsets.rend());
       auto tiles =
-          emitTileBody(op, rewriter, chunkedArgs, perDimOffsets, result);
+          emitTileBody(op, rewriter, chunkedArgs, reversedOffsets, result);
       scatterTiles(rewriter, loc, tiles, flatOffset, vectorSize, tensorAccPtrs,
                    tensorElemTys);
     }
@@ -394,6 +405,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
+    LDBG("Inline generic body into dynamic loop");
+
     Block *currentBlock = rewriter.getInsertionBlock();
     Block *afterBlock =
         rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
@@ -415,7 +428,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     // loop body: emit tile, increment counter
     rewriter.setInsertionPointToEnd(loopBody);
-#if 1
     // Decompose flat tile index into per-dim tile offsets
     unsigned rank = blockShape.size();
     SmallVector<Value> tileOffsets(rank);
@@ -428,16 +440,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     }
     // Flat offset for accumulator scatter (tile-major layout)
     Value flatTileOffset = b.mul(loopI, b.i32_val(vectorSize));
-#else
-    Value tileOffset =
-        LLVM::MulOp::create(rewriter, loc, loopI, b.i32_val(vectorSize));
-#endif
     auto tileArgs = buildDynamicChunkedArgs(op, adaptor, rewriter,
                                             flatTileOffset, vectorSize);
-    Value unused;
-    // TODO: can we always inline here instead of clone?
-#if 1
-
     const bool hasReductions = !op.getCombiners().empty();
     // TODO: consider asserting that generic body region has one block on the
     // emitTileBody/clone path
@@ -481,15 +485,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           yieldOp, SmallVector<Value>{nextI}, loopHeader);
       break; // only one ttc.yield per generic body
     }
-
-#else
-    auto loopTiles = emitTileBody(op, rewriter, tileArgs, tileOffsets, unused);
-    scatterTiles(rewriter, loc, loopTiles, flatTileOffset, vectorSize,
-                 tensorAccPtrs, tensorElemTys);
-
-    Value nextI = LLVM::AddOp::create(rewriter, loc, loopI, b.i32_val(1));
-    LLVM::BrOp::create(rewriter, loc, ValueRange{nextI}, loopHeader);
-#endif
   }
 
   LogicalResult
@@ -516,6 +511,10 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     const bool hasReductions = !op.getCombiners().empty();
     const unsigned numCombinerBlocks = op.getCombiners().getBlocks().size();
+
+    LDBG("Lowering genericOp with vectorSize = "
+         << vectorSize << ", numChunks = " << numChunks << ", hasReductions = "
+         << hasReductions << ", numCombinerBlocks = " << numCombinerBlocks);
 
     // Tensor results are materialized as thread-local global arrays rather than
     // LLVM vectors. This avoids loop-carried <blockSize x elemTy> phi nodes
@@ -560,6 +559,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       }
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(&func.getBody().front());
+      LDBG("Creating thread local global allocation `"
+           << globalName << "` for tensor of size " << blockSize);
       Value globalPtr = LLVM::AddressOfOp::create(
           rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext()),
           globalName);

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -111,14 +111,17 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
   SmallVector<Value> emitTileBody(cpu::GenericOp op,
                                   ConversionPatternRewriter &rewriter,
-                                  ArrayRef<Value> chunkedArgs, Value tileOffset,
+                                  ArrayRef<Value> chunkedArgs,
+                                  ArrayRef<Value> tileOffsets,
                                   Value &result) const {
     Block *body = &op.getBody().front();
     const bool hasReductions = !op.getCombiners().empty();
 
     // clone the body of the generic op for this chunk only
     IRMapping mapping;
-    mapping.map(body->getArgument(0), tileOffset);
+    for (auto [blockArg, offset] : llvm::zip(
+             body->getArguments().take_front(tileOffsets.size()), tileOffsets))
+      mapping.map(blockArg, offset);
     for (auto [bodyArg, chunkedArg] :
          llvm::zip(body->getArguments().drop_front(), chunkedArgs))
       mapping.map(bodyArg, chunkedArg);
@@ -259,7 +262,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       SmallVector<Value> chunkedArgs =
           buildStaticChunkedArgs(op, adaptor, rewriter, i, vectorSize);
       Value chunkOffset = b.i32_val(i * vectorSize);
-      auto tiles = emitTileBody(op, rewriter, chunkedArgs, chunkOffset, result);
+      auto tiles =
+          emitTileBody(op, rewriter, chunkedArgs, {chunkOffset}, result);
       scatterTiles(rewriter, loc, tiles, chunkOffset, vectorSize, tensorAccPtrs,
                    tensorElemTys);
     }
@@ -281,7 +285,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     auto firstArgs =
         buildStaticChunkedArgs(op, adaptor, rewriter, 0, vectorSize);
     auto firstTiles =
-        emitTileBody(op, rewriter, firstArgs, b.i32_val(0), result);
+        emitTileBody(op, rewriter, firstArgs, {b.i32_val(0)}, result);
     scatterTiles(rewriter, loc, firstTiles, b.i32_val(0), vectorSize,
                  tensorAccPtrs, tensorElemTys);
 
@@ -317,7 +321,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         buildDynamicChunkedArgs(op, adaptor, rewriter, tileOffset, vectorSize);
     Value tileResult = loopAcc;
     auto loopTiles =
-        emitTileBody(op, rewriter, tileArgs, tileOffset, tileResult);
+        emitTileBody(op, rewriter, tileArgs, {tileOffset}, tileResult);
     scatterTiles(rewriter, loc, loopTiles, tileOffset, vectorSize,
                  tensorAccPtrs, tensorElemTys);
     Value nextI = LLVM::AddOp::create(rewriter, loc, loopI, b.i32_val(1));
@@ -334,7 +338,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
   // iteration peeling is needed since there is no accumulator to bootstrap.
   void emitLoop(cpu::GenericOp op, OpAdaptor adaptor,
                 ConversionPatternRewriter &rewriter, unsigned numChunks,
-                unsigned vectorSize, ArrayRef<Value> tensorAccPtrs,
+                unsigned vectorSize, ArrayRef<int32_t> blockShape,
+                ArrayRef<int32_t> tileShape, ArrayRef<Value> tensorAccPtrs,
                 ArrayRef<Type> tensorElemTys) const {
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -360,13 +365,28 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     // loop body: emit tile, increment counter
     rewriter.setInsertionPointToEnd(loopBody);
+#if 1
+    // Decompose flat tile index into per-dim tile offsets
+    unsigned rank = blockShape.size();
+    SmallVector<Value> tileOffsets(rank);
+    Value remaining = loopI;
+    for (int d = rank - 1; d >= 0; --d) {
+      unsigned nc = blockShape[d] / tileShape[d];
+      Value chunkIdx = b.urem(remaining, b.i32_val(nc));
+      tileOffsets[d] = b.mul(chunkIdx, b.i32_val(tileShape[d]));
+      remaining = b.udiv(remaining, b.i32_val(nc));
+    }
+    // Flat offset for accumulator scatter (tile-major layout)
+    Value flatTileOffset = b.mul(loopI, b.i32_val(vectorSize));
+#else
     Value tileOffset =
         LLVM::MulOp::create(rewriter, loc, loopI, b.i32_val(vectorSize));
-    auto tileArgs =
-        buildDynamicChunkedArgs(op, adaptor, rewriter, tileOffset, vectorSize);
+#endif
+    auto tileArgs = buildDynamicChunkedArgs(op, adaptor, rewriter,
+                                            flatTileOffset, vectorSize);
     Value unused;
-    auto loopTiles = emitTileBody(op, rewriter, tileArgs, tileOffset, unused);
-    scatterTiles(rewriter, loc, loopTiles, tileOffset, vectorSize,
+    auto loopTiles = emitTileBody(op, rewriter, tileArgs, tileOffsets, unused);
+    scatterTiles(rewriter, loc, loopTiles, flatTileOffset, vectorSize,
                  tensorAccPtrs, tensorElemTys);
     Value nextI = LLVM::AddOp::create(rewriter, loc, loopI, b.i32_val(1));
     LLVM::BrOp::create(rewriter, loc, ValueRange{nextI}, loopHeader);
@@ -388,10 +408,11 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     assert(blockShape.size() == tileShape.size() && !blockShape.empty() &&
            "blockShape and tileShape must be non-empty and of the same size");
 
-    // TODO: assuming 1D shapes
-    assert(blockShape.size() == 1);
-    unsigned vectorSize = tileShape[0];
-    unsigned numChunks = blockShape[0] / vectorSize;
+    unsigned vectorSize = 1, numChunks = 1;
+    for (unsigned d = 0; d < blockShape.size(); ++d) {
+      vectorSize *= tileShape[d];
+      numChunks *= blockShape[d] / tileShape[d];
+    }
 
     const bool hasReductions = !op.getCombiners().empty();
     const unsigned numCombinerBlocks = op.getCombiners().getBlocks().size();
@@ -463,15 +484,20 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         });
 
     Value result;
-    if (requiresTensorArgMaterialization || numChunks == 1)
+    if (requiresTensorArgMaterialization || numChunks == 1) {
+      assert(blockShape.size() == 1 &&
+             "only support rank-1 generic tiles in unrolled path");
       emitUnrolled(op, adaptor, rewriter, numChunks, vectorSize, result,
                    tensorAccPtrs, tensorElemTys);
-    else if (hasReductions)
+    } else if (hasReductions) {
+      assert(blockShape.size() == 1 &&
+             "only support rank-1 generic tiles in reductions path");
       emitLoopWithReductions(op, adaptor, rewriter, numChunks, vectorSize,
                              result, tensorAccPtrs, tensorElemTys);
-    else
-      emitLoop(op, adaptor, rewriter, numChunks, vectorSize, tensorAccPtrs,
-               tensorElemTys);
+    } else {
+      emitLoop(op, adaptor, rewriter, numChunks, vectorSize, blockShape,
+               tileShape, tensorAccPtrs, tensorElemTys);
+    }
 
     SmallVector<Value> replacements;
     if (result)

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -55,7 +55,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     SmallVector<Value> chunkedArgs;
 
     for (auto [opIdx, origArg, llvmArg] : llvm::enumerate(
-             body->getArguments().drop_front(), adaptor.getOperands())) {
+             body->getArguments().drop_front(op.getNumInductionVars()),
+             adaptor.getOperands())) {
 
       if (!isa<RankedTensorType>(origArg.getType())) {
         // forward constants and scalars without chunking
@@ -123,7 +124,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
              body->getArguments().take_front(tileOffsets.size()), tileOffsets))
       mapping.map(blockArg, offset);
     for (auto [bodyArg, chunkedArg] :
-         llvm::zip(body->getArguments().drop_front(), chunkedArgs))
+         llvm::zip(body->getArguments().drop_front(op.getNumInductionVars()),
+                   chunkedArgs))
       mapping.map(bodyArg, chunkedArg);
 
     SmallVector<Value> tensorTiles;
@@ -213,7 +215,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     SmallVector<Value> tileArgs;
 
     for (auto [opIdx, origArg, llvmArg] : llvm::enumerate(
-             body->getArguments().drop_front(), adaptor.getOperands())) {
+             body->getArguments().drop_front(op.getNumInductionVars()),
+             adaptor.getOperands())) {
       if (Value ptrArg = getGenericOutputTensorAsPtr(op, opIdx, llvmArg)) {
         // Load this tile's elements from the alloca produced by the prior
         // generic and pack them into the tile struct.
@@ -385,11 +388,47 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     auto tileArgs = buildDynamicChunkedArgs(op, adaptor, rewriter,
                                             flatTileOffset, vectorSize);
     Value unused;
+    // TODO: can we always inline here instead of clone?
+#if 1
+
+    const bool hasReductions = !op.getCombiners().empty();
+    // TODO: consider asserting that generic body region has one block on the
+    // emitTileBody/clone path
+    assert(!hasReductions &&
+           "cannot handle generic reductions on the inline loop path");
+
+    Region &bodyRegion = op.getBody();
+    Block *bodyEntry = &bodyRegion.front();
+
+    // Move all blocks into the parent region before afterBlock.
+    rewriter.inlineRegionBefore(bodyRegion, *afterBlock->getParent(),
+                                afterBlock->getIterator());
+
+    for (Block &block : llvm::make_range(bodyEntry->getIterator(),
+                                         afterBlock->getIterator())) {
+      auto yieldOp = dyn_cast<cpu::YieldOp>(block.getTerminator());
+      if (!yieldOp)
+        continue;
+
+      rewriter.setInsertionPoint(yieldOp);
+      SmallVector<Value> loopTiles = llvm::to_vector(yieldOp.getValues());
+      scatterTiles(rewriter, loc, loopTiles, flatTileOffset, vectorSize,
+                   tensorAccPtrs, tensorElemTys);
+      Value nextI =
+          LLVM::AddOp::create(rewriter, op.getLoc(), loopI, b.i32_val(1));
+      rewriter.replaceOpWithNewOp<LLVM::BrOp>(
+          yieldOp, SmallVector<Value>{nextI}, loopHeader);
+      break; // only one ttc.yield per generic body
+    }
+
+#else
     auto loopTiles = emitTileBody(op, rewriter, tileArgs, tileOffsets, unused);
     scatterTiles(rewriter, loc, loopTiles, flatTileOffset, vectorSize,
                  tensorAccPtrs, tensorElemTys);
+
     Value nextI = LLVM::AddOp::create(rewriter, loc, loopI, b.i32_val(1));
     LLVM::BrOp::create(rewriter, loc, ValueRange{nextI}, loopHeader);
+#endif
   }
 
   LogicalResult
@@ -471,8 +510,9 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     // (llvm.extractvalue only accepts attribute indices). Alloca-backed tensors
     // from a prior generic are GEP-indexed and support dynamic offsets.
     const bool requiresTensorArgMaterialization = llvm::any_of(
-        llvm::enumerate(llvm::zip(body->getArguments().drop_front(),
-                                  adaptor.getOperands())),
+        llvm::enumerate(
+            llvm::zip(body->getArguments().drop_front(op.getNumInductionVars()),
+                      adaptor.getOperands())),
         [this, &op](auto pair) {
           auto [opIdx, argPair] = pair;
           auto [origArg, llvmArg] = argPair;

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -6,6 +6,7 @@
 
 #include "PatternTritonGPUOpToLLVM.h"
 #include <functional>
+#include <numeric>
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -516,7 +517,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
          llvm::drop_begin(op.getResultTypes(), numCombinerBlocks)) {
       auto tensorTy = cast<RankedTensorType>(resultTy);
       int64_t blockSize = std::accumulate(blockShape.begin(), blockShape.end(),
-                                          1, std::multiplies<>());
+                                          int64_t{1}, std::multiplies<>());
       Type elemTy = getTypeConverter()->convertType(tensorTy.getElementType());
       tensorElemTys.push_back(elemTy);
 

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -136,40 +136,59 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         if (yieldOp.getValues().empty())
           continue;
 
-        // TODO: this should still hold because only reduceop rewrites introduce
-        // materialized tensors. But eventually we can lift that limitation and
-        // allow any generic to materialize output tensors
-        assert(hasReductions &&
-               "unexpected yield op result in generic without reductions");
         auto yieldOpValues = llvm::to_vector(llvm::map_range(
             yieldOp.getValues(), [&](Value v) { return mapping.lookup(v); }));
-        if (!result) {
-          result = yieldOpValues[0];
+
+        if (hasReductions) {
+          if (!result) {
+            result = yieldOpValues[0];
+          } else {
+            // combine with the previous reduction result using the same
+            // combiner region
+            auto *combinerBlock = &op.getCombiners().front();
+            IRMapping combMapping;
+            combMapping.map(combinerBlock->getArgument(0), result);
+            combMapping.map(combinerBlock->getArgument(1), yieldOpValues[0]);
+
+            auto terminator =
+                cast<cpu::YieldOp>(combinerBlock->getTerminator());
+            auto yieldVals = terminator.getValues();
+            assert(
+                yieldVals.size() == 1 &&
+                "expected exactly one value yielded from the combiner block");
+
+            Operation *combinerOp = yieldVals.front().getDefiningOp();
+            assert(combinerOp && "expected yielded value to be defined by an "
+                                 "op in the combiner block");
+            auto newCombiner = rewriter.clone(*combinerOp, combMapping);
+            result = newCombiner->getResult(0);
+          }
+
+          // materialzied tensor values are currently added to yield op after
+          // scalars
+          unsigned numCombinerBlocks = op.getCombiners().getBlocks().size();
+          for (unsigned k = numCombinerBlocks; k < yieldOpValues.size(); ++k)
+            tensorTiles.push_back(yieldOpValues[k]);
         } else {
-          // combine with the previous reduction result using the same
-          // combiner region
-          auto *combinerBlock = &op.getCombiners().front();
-          IRMapping combMapping;
-          combMapping.map(combinerBlock->getArgument(0), result);
-          combMapping.map(combinerBlock->getArgument(1), yieldOpValues[0]);
-
-          auto terminator = cast<cpu::YieldOp>(combinerBlock->getTerminator());
-          auto yieldVals = terminator.getValues();
-          assert(yieldVals.size() == 1 &&
-                 "expected exactly one value yielded from the combiner block");
-
-          Operation *combinerOp = yieldVals.front().getDefiningOp();
-          assert(combinerOp && "expected yielded value to be defined by an "
-                               "op in the combiner block");
-          auto newCombiner = rewriter.clone(*combinerOp, combMapping);
-          result = newCombiner->getResult(0);
+#if 1
+          for (unsigned k = 0; k < yieldOpValues.size(); ++k)
+            tensorTiles.push_back(yieldOpValues[k]);
+#else
+          // TODO: we should assert that all users are generics since we are
+          // about to materialize a tensor in a format only generics can handle
+          assert(yieldOpValues.size() == 1 &&
+                 "only support scattering one generic tensor result currently");
+          assert(op.getBlockShape() == op.getTileShape() &&
+                 "only support materializing tensors in static path for "
+                 "generics with num_tiles = 1");
+          Location loc = yieldOp.getLoc();
+          auto b = TritonLLVMOpBuilder(loc, rewriter);
+          scatterTiles(rewriter, loc, yieldOpValues,
+                       /*tileOffset= */ b.i32_val(0), /*vectorSize= */ 1, {},
+                       {});
+#endif
         }
 
-        // materialzied tensor values are currently added to yield op after
-        // scalars
-        unsigned numCombinerBlocks = op.getCombiners().getBlocks().size();
-        for (unsigned k = numCombinerBlocks; k < yieldOpValues.size(); ++k)
-          tensorTiles.push_back(yieldOpValues[k]);
       } else {
         rewriter.clone(bOp, mapping);
       }
@@ -572,6 +591,18 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       emitLoopWithReductions(op, adaptor, rewriter, numChunks, vectorSize,
                              result, tensorAccPtrs, tensorElemTys);
     } else {
+      const bool genericHasTensorOutputs =
+          llvm::any_of(op->getResults(), [](Value result) {
+            return isa<RankedTensorType>(result.getType());
+          });
+      const bool allUsersAreGeneric =
+          genericHasTensorOutputs
+              ? llvm::all_of(
+                    op->getUsers(),
+                    [](Operation *user) { return isa<cpu::GenericOp>(user); })
+              : true;
+      assert(allUsersAreGeneric && "expected all generic op users to also be "
+                                   "generic ops on dynamic path");
       emitLoop(op, adaptor, rewriter, numChunks, vectorSize, blockShape,
                tileShape, tensorAccPtrs, tensorElemTys);
     }

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -254,9 +254,13 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           tileStruct =
               LLVM::InsertValueOp::create(rewriter, loc, tileStruct, elem, {j});
         }
+#if 1
+        tileArgs.push_back(tileStruct);
+#else
         tileArgs.push_back(UnrealizedConversionCastOp::create(
                                rewriter, loc, origArg.getType(), tileStruct)
                                .getResult(0));
+#endif
       } else if (isa<PointerType>(origArg.getType())) {
         // we might have a tt.ptr hiding in an unrealized conversion cast due to
         // late conversion of generic op block arguments. Use unrealized

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -170,23 +170,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           for (unsigned k = numCombinerBlocks; k < yieldOpValues.size(); ++k)
             tensorTiles.push_back(yieldOpValues[k]);
         } else {
-#if 1
           for (unsigned k = 0; k < yieldOpValues.size(); ++k)
             tensorTiles.push_back(yieldOpValues[k]);
-#else
-          // TODO: we should assert that all users are generics since we are
-          // about to materialize a tensor in a format only generics can handle
-          assert(yieldOpValues.size() == 1 &&
-                 "only support scattering one generic tensor result currently");
-          assert(op.getBlockShape() == op.getTileShape() &&
-                 "only support materializing tensors in static path for "
-                 "generics with num_tiles = 1");
-          Location loc = yieldOp.getLoc();
-          auto b = TritonLLVMOpBuilder(loc, rewriter);
-          scatterTiles(rewriter, loc, yieldOpValues,
-                       /*tileOffset= */ b.i32_val(0), /*vectorSize= */ 1, {},
-                       {});
-#endif
         }
 
       } else {
@@ -254,13 +239,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           tileStruct =
               LLVM::InsertValueOp::create(rewriter, loc, tileStruct, elem, {j});
         }
-#if 1
         tileArgs.push_back(tileStruct);
-#else
-        tileArgs.push_back(UnrealizedConversionCastOp::create(
-                               rewriter, loc, origArg.getType(), tileStruct)
-                               .getResult(0));
-#endif
       } else if (isa<PointerType>(origArg.getType())) {
         // we might have a tt.ptr hiding in an unrealized conversion cast due to
         // late conversion of generic op block arguments. Use unrealized

--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -204,7 +204,7 @@ def benchmark(M, N, provider):
     return gbps(ms)
 
 
-benchmark.run(show_plots=True, print_data=True)
+benchmark.run(show_plots=False, print_data=True)
 
 # %%
 # In the above plot, we can see that:

--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -204,7 +204,7 @@ def benchmark(M, N, provider):
     return gbps(ms)
 
 
-benchmark.run(show_plots=False, print_data=True)
+benchmark.run(show_plots=True, print_data=True)
 
 # %%
 # In the above plot, we can see that:

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -219,14 +219,18 @@ def get_hip_autotune_config():
 
 def get_cpu_autotune_config():
     sizes = [
-        {'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6},
-        {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4},
-        {'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6},
-        {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6},
-        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4},
-        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4},
-        #{'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4},
-        #{'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 16, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 4},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 16, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 4},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 4},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 4},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 6},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 16, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 6},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 6},
+        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 6},
     ]
     return [triton.Config(s | {'matrix_instr_nonkdim': 16}, num_warps=1, num_stages=2) for s in sizes]
 
@@ -381,8 +385,6 @@ def matmul(a, b, activation=""):
 torch.manual_seed(0)
 a = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
 b = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
-#a = torch.ones((4, 16), device=DEVICE, dtype=torch.float16)
-#b = torch.ones((16, 8), device=DEVICE, dtype=torch.float16)
 
 triton_output = matmul(a, b)
 torch_output = torch.matmul(a, b)
@@ -393,7 +395,6 @@ if torch.allclose(triton_output, torch_output, atol=1e-2, rtol=0):
     print("✅ Triton and Torch match")
 else:
     print("❌ Triton and Torch differ")
-
 
 TORCH_HAS_FP8 = hasattr(torch, "float8_e5m2")
 if TORCH_HAS_FP8 and is_cuda():
@@ -468,4 +469,4 @@ def benchmark(M, N, K, provider, fp8_inputs):
     return perf(ms), perf(max_ms), perf(min_ms)
 
 
-benchmark.run(show_plots=True, print_data=True)
+benchmark.run(show_plots=False, print_data=True)

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -385,7 +385,6 @@ def matmul(a, b, activation=""):
 torch.manual_seed(0)
 a = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
 b = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
-
 triton_output = matmul(a, b)
 torch_output = torch.matmul(a, b)
 print(f"triton_output_with_fp16_inputs={triton_output}")

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -219,11 +219,14 @@ def get_hip_autotune_config():
 
 def get_cpu_autotune_config():
     sizes = [
-        #{'BLOCK_SIZE_M': 2, 'BLOCK_SIZE_N': 4, 'BLOCK_SIZE_K': 4, 'GROUP_SIZE_M': 1},
-        #{'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 4, 'BLOCK_SIZE_K': 4, 'GROUP_SIZE_M': 1},
-        #{'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 4, 'GROUP_SIZE_M': 1},
-        #{'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
-        {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 16, 'BLOCK_SIZE_K': 16, 'GROUP_SIZE_M': 1},
+        {'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6},
+        {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4},
+        {'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6},
+        {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6},
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4},
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4},
+        #{'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4},
+        #{'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6},
     ]
     return [triton.Config(s | {'matrix_instr_nonkdim': 16}, num_warps=1, num_stages=2) for s in sizes]
 
@@ -378,6 +381,9 @@ def matmul(a, b, activation=""):
 torch.manual_seed(0)
 a = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
 b = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
+#a = torch.ones((4, 16), device=DEVICE, dtype=torch.float16)
+#b = torch.ones((16, 8), device=DEVICE, dtype=torch.float16)
+
 triton_output = matmul(a, b)
 torch_output = torch.matmul(a, b)
 print(f"triton_output_with_fp16_inputs={triton_output}")
@@ -388,9 +394,6 @@ if torch.allclose(triton_output, torch_output, atol=1e-2, rtol=0):
 else:
     print("❌ Triton and Torch differ")
 
-import sys
-
-sys.exit(0)
 
 TORCH_HAS_FP8 = hasattr(torch, "float8_e5m2")
 if TORCH_HAS_FP8 and is_cuda():
@@ -434,7 +437,7 @@ for fp8_inputs in [False, True]:
     configs.append(
         triton.testing.Benchmark(
             x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
-            x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
+            x_vals=[128 * i for i in range(2, 8)],  # Different possible values for `x_name`
             line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
             # Possible values for `line_arg`
             # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
@@ -450,8 +453,8 @@ for fp8_inputs in [False, True]:
 
 @triton.testing.perf_report(configs)
 def benchmark(M, N, K, provider, fp8_inputs):
-    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
+    a = torch.randn((M, K), device=DEVICE, dtype=torch.float32)
+    b = torch.randn((K, N), device=DEVICE, dtype=torch.float32)
     if TORCH_HAS_FP8 and fp8_inputs:
         a = a.to(torch.float8_e5m2)
         b = b.T
@@ -465,4 +468,4 @@ def benchmark(M, N, K, provider, fp8_inputs):
     return perf(ms), perf(max_ms), perf(min_ms)
 
 
-#benchmark.run(show_plots=True, print_data=True)
+benchmark.run(show_plots=True, print_data=True)

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -219,11 +219,11 @@ def get_hip_autotune_config():
 
 def get_cpu_autotune_config():
     sizes = [
-        {'BLOCK_SIZE_M': 2, 'BLOCK_SIZE_N': 4, 'BLOCK_SIZE_K': 4, 'GROUP_SIZE_M': 1},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 4, 'BLOCK_SIZE_K': 4, 'GROUP_SIZE_M': 1},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 4, 'GROUP_SIZE_M': 1},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
-        {'BLOCK_SIZE_M': 8, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
+        #{'BLOCK_SIZE_M': 2, 'BLOCK_SIZE_N': 4, 'BLOCK_SIZE_K': 4, 'GROUP_SIZE_M': 1},
+        #{'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 4, 'BLOCK_SIZE_K': 4, 'GROUP_SIZE_M': 1},
+        #{'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 4, 'GROUP_SIZE_M': 1},
+        #{'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
+        {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 16, 'BLOCK_SIZE_K': 16, 'GROUP_SIZE_M': 1},
     ]
     return [triton.Config(s | {'matrix_instr_nonkdim': 16}, num_warps=1, num_stages=2) for s in sizes]
 
@@ -387,6 +387,10 @@ if torch.allclose(triton_output, torch_output, atol=1e-2, rtol=0):
     print("✅ Triton and Torch match")
 else:
     print("❌ Triton and Torch differ")
+
+import sys
+
+sys.exit(0)
 
 TORCH_HAS_FP8 = hasattr(torch, "float8_e5m2")
 if TORCH_HAS_FP8 and is_cuda():

--- a/test/Analysis/axis-info-generic.mlir
+++ b/test/Analysis/axis-info-generic.mlir
@@ -50,3 +50,71 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
         tt.return
     }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
+  tt.func public @store_2d_vectorized(
+      %c_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %data: tensor<4x8xf16, #blocked> {tt.divisibility = 16 : i32},
+      %M: i32 {tt.divisibility = 16 : i32}, %N: i32 {tt.divisibility = 16 : i32},
+      %stride_cm: i32 {tt.divisibility = 16 : i32},
+      %offs_am: i32 {tt.divisibility = 16 : i32}, %offs_bn: i32 {tt.divisibility = 16 : i32}) {
+
+    // 4 M-tiles × 1 N-tile = 4 body invocations, each must emit one vector<8xf16> store.
+    // CHECK-COUNT-4: ttc.masked_store {{.*}} : (!llvm.ptr<1>, vector<8xf16>, vector<8xi1>) -> ()
+    // CHECK-NOT: ttc.masked_store {{.*}} : (!llvm.ptr<1>, vector<1xf16>
+    ttc.generic %data, %c_ptr, %stride_cm, %M, %N, %offs_am, %offs_bn
+        attributes {blockShape = array<i32: 4, 8>, tileShape = array<i32: 1, 8>} body {
+    ^bb0(%tile_n: i32, %tile_m: i32,
+         %tile_data: tensor<1x8xf16, #blocked>,
+         %ptr: !tt.ptr<f16>, %stride: i32, %m_bound: i32, %n_bound: i32,
+         %row_base: i32, %col_base: i32):
+
+      // Column offsets: col_base + [0..7]
+      %col_range = tt.make_range {end = 8 : i32, start = 0 : i32}
+          : tensor<8xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+      %col_base_t = tt.splat %col_base : i32 -> tensor<8xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+      %cols = arith.addi %col_base_t, %col_range
+          : tensor<8xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+      %cols_2d = tt.expand_dims %cols {axis = 0 : i32}
+          : tensor<8xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x8xi32, #blocked>
+
+      // Row offset: row_base + M-tile index
+      %row_range = ttc.make_dynamic_range %tile_m
+          : tensor<1xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %row_base_t = tt.splat %row_base : i32 -> tensor<1xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %rows = arith.addi %row_base_t, %row_range
+          : tensor<1xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %rows_2d = tt.expand_dims %rows {axis = 1 : i32}
+          : tensor<1xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<1x1xi32, #blocked>
+
+      // Mask: (row < M) & (col < N)
+      %n_t = tt.splat %n_bound : i32 -> tensor<1x8xi32, #blocked>
+      %col_mask = arith.cmpi slt, %cols_2d, %n_t : tensor<1x8xi32, #blocked>
+      %m_t = tt.splat %m_bound : i32 -> tensor<1x1xi32, #blocked>
+      %row_mask = arith.cmpi slt, %rows_2d, %m_t : tensor<1x1xi32, #blocked>
+      %row_mask_bcast = tt.broadcast %row_mask
+          : tensor<1x1xi1, #blocked> -> tensor<1x8xi1, #blocked>
+      %mask = arith.andi %row_mask_bcast, %col_mask : tensor<1x8xi1, #blocked>
+
+      // Pointer: ptr + row * stride + col
+      %stride_t = tt.splat %stride : i32 -> tensor<1x1xi32, #blocked>
+      %row_off = arith.muli %rows_2d, %stride_t : tensor<1x1xi32, #blocked>
+      %ptr_base = tt.splat %ptr : !tt.ptr<f16> -> tensor<1x1x!tt.ptr<f16>, #blocked>
+      %ptrs_r = tt.addptr %ptr_base, %row_off
+          : tensor<1x1x!tt.ptr<f16>, #blocked>, tensor<1x1xi32, #blocked>
+      %ptrs_bcast = tt.broadcast %ptrs_r
+          : tensor<1x1x!tt.ptr<f16>, #blocked> -> tensor<1x8x!tt.ptr<f16>, #blocked>
+      %ptrs = tt.addptr %ptrs_bcast, %cols_2d
+          : tensor<1x8x!tt.ptr<f16>, #blocked>, tensor<1x8xi32, #blocked>
+
+      tt.store %ptrs, %tile_data, %mask : tensor<1x8x!tt.ptr<f16>, #blocked>
+      ttc.yield
+    } combiners {} : (tensor<4x8xf16, #blocked>, !tt.ptr<f16>, i32, i32, i32, i32, i32) -> ()
+
+    tt.return
+  }
+}

--- a/test/Analysis/axis-info-generic.mlir
+++ b/test/Analysis/axis-info-generic.mlir
@@ -38,7 +38,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
                 %offset_ptrs = tt.addptr %ptrs, %offsets : tensor<4x!tt.ptr<f32>, #blocked>, tensor<4xi32, #blocked>
                 // COM: no un-rolled prologue, check for branch to loop pre-header
                 // CHECK: llvm.br ^bb1
-                // CHECK: llvm.cond_br {{.*}}, ^bb2, ^bb3
+                // COM: loop branch
+                // CHECK: llvm.cond_br {{.*}}, ^bb2, ^bb4
+                // COM: branch to inlined block
+                // CHECK: llvm.br ^bb3
                 // CHECK: ttc.masked_load {{.*}} -> vector<4xf32>
                 %ret = tt.load %offset_ptrs : tensor<4x!tt.ptr<f32>, #blocked>
                 ttc.yield


### PR DESCRIPTION
Adds support for wrapping `tt.dot` ops in `ttc.generic`. Major changes include:
* Support wrapping a dot op embedded in a K loop in `ttc.generic`
* Support fusing expand dims and broadcast ops into `ttc.generic` 
* Support 2D tiled `ttc.generic` lowering 
* Unblock tutorial 3 benchmarking in GitHub Actions + add more configs 
* Inline all generic blocks and convert signatures in the dynamic loop path instead of cloning ops

The K loop wrapping is currently very specific - but with the new greedy fusion algorithm I think I can relax that. Will make that a target of subsequent work. Note that the K loop wrapping means some `test_dot` tests in `test_core` don't run yet. We use the tutorial to validate this work with `test_core` validating future work. 