### PR TITLE
[GenericOp] Keep induction var ordering consistent with block shape

### DIFF
--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -729,10 +729,23 @@ struct FuseMakeRangeIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
         // just fuse the existing op
         newOp = rewriter.clone(*op, mapping);
       } else {
+        auto rank = tileShape.size();
         auto newResultType = updateTensorType(resultType, tileShape);
         auto sliceEncodingAttr =
             dyn_cast<triton::gpu::SliceEncodingAttr>(resultType.getEncoding());
-        unsigned dim = sliceEncodingAttr ? sliceEncodingAttr.getDim() : 0;
+        unsigned dim;
+        if (!sliceEncodingAttr) {
+          assert(rank == 1 && "make dynamic range op without slice encoding "
+                              "should be inside a 1D generic");
+          dim = 0;
+        } else {
+          // Body induction vars are ordered outermost-first, matching
+          // blockShape. A SliceEncodingAttr with dim=d encodes a 1D tensor in
+          // the direction of tensor-dim (1-d),
+          // which sits at blockShape index (rank-2) + (1-d) = rank-1-d.
+          dim =
+              genericOp.getBlockShape().size() - 1 - sliceEncodingAttr.getDim();
+        }
         newOp = triton::cpu::MakeDynamicRangeOp::create(
             rewriter, makeRangeOp.getLoc(), newResultType,
             genericOp.getTileOffset(dim));

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -289,15 +289,13 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       SmallVector<Value> perDimOffsets(rank);
       unsigned remaining = i;
       LDBG("i = " << i);
-      // Body induction vars are ordered innermost-first (col, then row), so
-      // store offsets at rank-1-d to match that convention.
       for (int d = rank - 1; d >= 0; --d) {
         unsigned nc = blockShape[d] / tileShape[d];
         unsigned chunkIdx = remaining % nc;
-        LDBG("perDimOffsets[" << rank - 1 - d << "] = " << chunkIdx << " * "
+        LDBG("perDimOffsets[" << d << "] = " << chunkIdx << " * "
                               << tileShape[d] << " = "
                               << (chunkIdx * tileShape[d]));
-        perDimOffsets[rank - 1 - d] = b.i32_val(chunkIdx * tileShape[d]);
+        perDimOffsets[d] = b.i32_val(chunkIdx * tileShape[d]);
         remaining /= nc;
       }
 
@@ -415,7 +413,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     for (int d = rank - 1; d >= 0; --d) {
       unsigned nc = blockShape[d] / tileShape[d];
       Value chunkIdx = b.urem(remaining, b.i32_val(nc));
-      tileOffsets[rank - 1 - d] = b.mul(chunkIdx, b.i32_val(tileShape[d]));
+      tileOffsets[d] = b.mul(chunkIdx, b.i32_val(tileShape[d]));
       remaining = b.udiv(remaining, b.i32_val(nc));
     }
     // Flat offset for accumulator scatter (tile-major layout)


### PR DESCRIPTION
Body induction variable arguments were previously ordered innermost-first (e.g. N offset at arg 0, M offset at arg 1 for a 2D generic), which is the reverse of the `blockShape`/`tileShape` operand order. This mismatch will cause incorrect offsets when additional outer dimensions (e.g. K) are prepended to `blockShape`. This change reorders body induction args to match `blockShape` operand order (outermost-first) in the LLVM lowering, and updates `TileAndFuse` to compensate by mapping `sliceEncodingAttr.getDim()` through `rank - 1 - dim` when selecting the corresponding body arg.