### PR TITLE
Emit nested LLVM loops in generic op lowering

### DIFF
--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -70,6 +70,14 @@ LogicalResult GenericOp::verify() {
 
   // Combiners region must have one block per scalar result.
   Region &combiners = getCombiners();
+  if (!combiners.getBlocks().empty()) {
+    // if we have combiners we are currently limited to only one block in the
+    // body region
+    if (body.getBlocks().size() != 1)
+      return emitOpError("currently only supports one block in "
+                         "the body region with populated combiners, got ")
+             << body.getBlocks().size();
+  }
   unsigned numScalarResults = std::accumulate(
       getResults().begin(), getResults().end(), 0, [](int sum, Value v) {
         if (!isa<RankedTensorType>(v.getType()))

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -425,7 +425,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                        Value &result, ArrayRef<Value> tensorAccPtrs,
                        ArrayRef<Type> tensorElemTys,
                        Block *innerAfterBlock = nullptr) const {
-#if 1
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -501,83 +500,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                           tensorAccPtrs, tensorElemTys, afterBlock);
           accOffsets.pop_back();
         });
-
-#else
-
-    Block *currentBlock = rewriter.getInsertionBlock();
-    Block *afterBlock =
-        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
-
-    // loop-carried value: (i: i32) only
-    Block *loopHeader = rewriter.createBlock(afterBlock, {i32_ty}, {loc});
-    Block *loopBody = rewriter.createBlock(afterBlock);
-
-    // currentBlock -> loopHeader(0)
-    rewriter.setInsertionPointToEnd(currentBlock);
-    LLVM::BrOp::create(rewriter, loc, ValueRange{b.i32_val(0)}, loopHeader);
-
-    // loopHeader: check i < numChunks, branch to body or exit
-    rewriter.setInsertionPointToEnd(loopHeader);
-    Value loopI = loopHeader->getArgument(0);
-    Value cond = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::ult,
-                                      loopI, b.i32_val(numChunks));
-    LLVM::CondBrOp::create(rewriter, loc, cond, loopBody, {}, afterBlock, {});
-
-    // loop body: emit tile, increment counter
-    rewriter.setInsertionPointToEnd(loopBody);
-    // Decompose flat tile index into per-dim tile offsets
-    unsigned rank = blockShape.size();
-    SmallVector<Value> tileOffsets(rank);
-    Value remaining = loopI;
-    for (int d = rank - 1; d >= 0; --d) {
-      unsigned nc = blockShape[d] / tileShape[d];
-      Value chunkIdx = b.urem(remaining, b.i32_val(nc));
-      tileOffsets[d] = b.mul(chunkIdx, b.i32_val(tileShape[d]));
-      remaining = b.udiv(remaining, b.i32_val(nc));
-    }
-    // Flat offset for accumulator scatter (tile-major layout)
-    Value flatTileOffset = b.mul(loopI, b.i32_val(vectorSize));
-    auto tileArgs = buildDynamicChunkedArgs(op, adaptor, rewriter,
-                                            flatTileOffset, vectorSize);
-
-    Region &bodyRegion = op.getBody();
-    Block *bodyEntry = &bodyRegion.front();
-
-    // Move all blocks into the parent region before afterBlock.
-    rewriter.inlineRegionBefore(bodyRegion, *afterBlock->getParent(),
-                                afterBlock->getIterator());
-
-    TypeConverter::SignatureConversion sigConv(bodyEntry->getNumArguments());
-    for (auto [idx, arg] : llvm::enumerate(bodyEntry->getArguments()))
-      sigConv.addInputs(idx, getTypeConverter()->convertType(arg.getType()));
-    bodyEntry = rewriter.applySignatureConversion(bodyEntry, sigConv,
-                                                  getTypeConverter());
-
-    // Branch from loopBody into the inlined region, passing induction vars then
-    // tile args as block arguments to match bodyEntry's argument list.
-    rewriter.setInsertionPointToEnd(loopBody);
-    SmallVector<Value> entryArgs;
-    entryArgs.append(tileOffsets.begin(), tileOffsets.end());
-    entryArgs.append(tileArgs.begin(), tileArgs.end());
-    LLVM::BrOp::create(rewriter, loc, entryArgs, bodyEntry);
-
-    for (Block &block : llvm::make_range(bodyEntry->getIterator(),
-                                         afterBlock->getIterator())) {
-      auto yieldOp = dyn_cast<cpu::YieldOp>(block.getTerminator());
-      if (!yieldOp)
-        continue;
-
-      rewriter.setInsertionPoint(yieldOp);
-      SmallVector<Value> loopTiles = llvm::to_vector(yieldOp.getValues());
-      scatterTiles(rewriter, loc, loopTiles, flatTileOffset, vectorSize,
-                   tensorAccPtrs, tensorElemTys);
-      Value nextI =
-          LLVM::AddOp::create(rewriter, op.getLoc(), loopI, b.i32_val(1));
-      rewriter.replaceOpWithNewOp<LLVM::BrOp>(
-          yieldOp, SmallVector<Value>{nextI}, loopHeader);
-      break; // only one ttc.yield per generic body
-    }
-#endif
   }
 
   LogicalResult

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -117,6 +117,9 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                                   ArrayRef<Value> chunkedArgs,
                                   ArrayRef<Value> tileOffsets,
                                   Value &result) const {
+    // TODO: assert that the body region has only one block
+    assert(op.getBody().getBlocks().size() == 1 &&
+           "expected generic op body to have one block");
     Block *body = &op.getBody().front();
     const bool hasReductions = !op.getCombiners().empty();
 
@@ -372,18 +375,134 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     result = afterResult;
   }
 
+  void emitSingleLoop(
+      ConversionPatternRewriter &rewriter, Location loc, int32_t numChunks,
+      int32_t tileSize,
+      llvm::function_ref<void(Value /*loopI*/, Value /*dimTileOffset*/,
+                              Block * /*loopHeader*/, Block * /*afterBlock*/)>
+          bodyFn) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    Block *currentBlock = rewriter.getInsertionBlock();
+    Block *afterBlock =
+        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+
+    // loop-carried value: (i: i32) only
+    Block *loopHeader = rewriter.createBlock(afterBlock, {i32_ty}, {loc});
+    Block *loopBody = rewriter.createBlock(afterBlock);
+
+    // currentBlock -> loopHeader(0)
+    rewriter.setInsertionPointToEnd(currentBlock);
+    LLVM::BrOp::create(rewriter, loc, ValueRange{b.i32_val(0)}, loopHeader);
+
+    // loopHeader: check i < numChunks, branch to body or exit
+    rewriter.setInsertionPointToEnd(loopHeader);
+    Value loopI = loopHeader->getArgument(0);
+    Value cond = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::ult,
+                                      loopI, b.i32_val(numChunks));
+    LLVM::CondBrOp::create(rewriter, loc, cond, loopBody, {}, afterBlock, {});
+
+    // loop body: emit tile, increment counter
+    rewriter.setInsertionPointToEnd(loopBody);
+
+    Value tileOffset = b.mul(loopI, b.i32_val(tileSize));
+    bodyFn(loopI, tileOffset, loopHeader, afterBlock);
+
+    Value nextI = LLVM::AddOp::create(rewriter, loc, loopI, b.i32_val(1));
+    LLVM::BrOp::create(rewriter, loc, ValueRange{nextI}, loopHeader);
+
+    rewriter.setInsertionPointToStart(afterBlock);
+  }
+
   // Path 3: emit a loop over tiles with no reduction accumulator.
   // Loops from i=0 to numChunks-1 carrying only the loop counter. No first-
   // iteration peeling is needed since there is no accumulator to bootstrap.
-  void emitLoop(cpu::GenericOp op, OpAdaptor adaptor,
-                ConversionPatternRewriter &rewriter, unsigned numChunks,
-                unsigned vectorSize, ArrayRef<int32_t> blockShape,
-                ArrayRef<int32_t> tileShape, ArrayRef<Value> tensorAccPtrs,
-                ArrayRef<Type> tensorElemTys) const {
+  void emitNestedLoops(cpu::GenericOp op, OpAdaptor adaptor,
+                       ConversionPatternRewriter &rewriter, unsigned dim,
+                       SmallVectorImpl<Value> &accOffsets, Value flatElemOffset,
+                       ArrayRef<int32_t> blockShape,
+                       ArrayRef<int32_t> tileShape, unsigned vectorSize,
+                       Value &result, ArrayRef<Value> tensorAccPtrs,
+                       ArrayRef<Type> tensorElemTys,
+                       Block *innerAfterBlock = nullptr) const {
+#if 1
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    LDBG("Inline generic body into dynamic loop");
+    unsigned rank = blockShape.size();
+
+    if (dim == rank) {
+      // innermost loop, inline generic op body
+      assert(innerAfterBlock &&
+             "expected inner after block for innermost loop");
+
+      Region &bodyRegion = op.getBody();
+      Block *bodyEntry = &bodyRegion.front();
+
+      // must be built before inlining the region since it references block
+      // arguments
+      auto tileArgs = buildDynamicChunkedArgs(op, adaptor, rewriter,
+                                              flatElemOffset, vectorSize);
+
+      rewriter.inlineRegionBefore(bodyRegion, *innerAfterBlock->getParent(),
+                                  innerAfterBlock->getIterator());
+
+      TypeConverter::SignatureConversion sigConv(bodyEntry->getNumArguments());
+      for (auto [idx, arg] : llvm::enumerate(bodyEntry->getArguments()))
+        sigConv.addInputs(idx, getTypeConverter()->convertType(arg.getType()));
+      bodyEntry = rewriter.applySignatureConversion(bodyEntry, sigConv,
+                                                    getTypeConverter());
+
+      SmallVector<Value> entryArgs(accOffsets.begin(), accOffsets.end());
+      entryArgs.append(tileArgs.begin(), tileArgs.end());
+      LLVM::BrOp::create(rewriter, loc, entryArgs, bodyEntry);
+
+      for (Block &block : llvm::make_range(bodyEntry->getIterator(),
+                                           innerAfterBlock->getIterator())) {
+        auto yieldOp = dyn_cast<cpu::YieldOp>(block.getTerminator());
+        if (!yieldOp)
+          continue;
+
+        rewriter.setInsertionPoint(yieldOp);
+        SmallVector<Value> loopTiles = llvm::to_vector(yieldOp.getValues());
+        scatterTiles(rewriter, loc, loopTiles, flatElemOffset, vectorSize,
+                     tensorAccPtrs, tensorElemTys);
+
+        // emit single loop handles branching to the next block, so just erase
+        // the yield and set the rewriter insertion point to the end of the last
+        // inlined block
+        rewriter.eraseOp(yieldOp);
+        rewriter.setInsertionPointToEnd(&block);
+        break; // only one ttc.yield per generic body
+      }
+
+      return;
+    }
+
+    // emit single loop, recurse to next level down
+    int32_t numChunks = blockShape[dim] / tileShape[dim];
+
+    int32_t innerStride = vectorSize;
+    for (unsigned d = dim + 1; d < rank; ++d) {
+      innerStride *= blockShape[d] / tileShape[d];
+    }
+
+    emitSingleLoop(
+        rewriter, loc, numChunks, tileShape[dim],
+        [&](Value loopI, Value dimTileOffset, Block *loopHeader,
+            Block *afterBlock) {
+          accOffsets.push_back(dimTileOffset);
+          Value newFlat =
+              LLVM::AddOp::create(rewriter, loc, flatElemOffset,
+                                  LLVM::MulOp::create(rewriter, loc, loopI,
+                                                      b.i32_val(innerStride)));
+          emitNestedLoops(op, adaptor, rewriter, dim + 1, accOffsets, newFlat,
+                          blockShape, tileShape, vectorSize, result,
+                          tensorAccPtrs, tensorElemTys, afterBlock);
+          accOffsets.pop_back();
+        });
+
+#else
 
     Block *currentBlock = rewriter.getInsertionBlock();
     Block *afterBlock =
@@ -420,11 +539,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     Value flatTileOffset = b.mul(loopI, b.i32_val(vectorSize));
     auto tileArgs = buildDynamicChunkedArgs(op, adaptor, rewriter,
                                             flatTileOffset, vectorSize);
-    const bool hasReductions = !op.getCombiners().empty();
-    // TODO: consider asserting that generic body region has one block on the
-    // emitTileBody/clone path
-    assert(!hasReductions &&
-           "cannot handle generic reductions on the inline loop path");
 
     Region &bodyRegion = op.getBody();
     Block *bodyEntry = &bodyRegion.front();
@@ -463,6 +577,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           yieldOp, SmallVector<Value>{nextI}, loopHeader);
       break; // only one ttc.yield per generic body
     }
+#endif
   }
 
   LogicalResult
@@ -586,8 +701,11 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
               : true;
       assert(allUsersAreGeneric && "expected all generic op users to also be "
                                    "generic ops on dynamic path");
-      emitLoop(op, adaptor, rewriter, numChunks, vectorSize, blockShape,
-               tileShape, tensorAccPtrs, tensorElemTys);
+      SmallVector<Value> accOffsets;
+      auto b = TritonLLVMOpBuilder(loc, rewriter);
+      emitNestedLoops(op, adaptor, rewriter, /*dim=*/0, accOffsets,
+                      b.i32_val(0), blockShape, tileShape, vectorSize, result,
+                      tensorAccPtrs, tensorElemTys);
     }
 
     SmallVector<Value> replacements;

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -112,12 +112,11 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     return chunkedArgs;
   }
 
-  SmallVector<Value> emitTileBody(cpu::GenericOp op,
-                                  ConversionPatternRewriter &rewriter,
-                                  ArrayRef<Value> chunkedArgs,
-                                  ArrayRef<Value> tileOffsets,
-                                  Value &result) const {
-    // TODO: assert that the body region has only one block
+  SmallVector<Value> cloneTileBody(cpu::GenericOp op,
+                                   ConversionPatternRewriter &rewriter,
+                                   ArrayRef<Value> chunkedArgs,
+                                   ArrayRef<Value> tileOffsets,
+                                   Value &result) const {
     assert(op.getBody().getBlocks().size() == 1 &&
            "expected generic op body to have one block");
     Block *body = &op.getBody().front();
@@ -305,7 +304,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       Value flatOffset = b.i32_val(i * vectorSize);
       LDBG("flatOffset = " << (i * vectorSize));
       auto tiles =
-          emitTileBody(op, rewriter, chunkedArgs, perDimOffsets, result);
+          cloneTileBody(op, rewriter, chunkedArgs, perDimOffsets, result);
       scatterTiles(rewriter, loc, tiles, flatOffset, vectorSize, tensorAccPtrs,
                    tensorElemTys);
     }
@@ -327,7 +326,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     auto firstArgs =
         buildStaticChunkedArgs(op, adaptor, rewriter, 0, vectorSize);
     auto firstTiles =
-        emitTileBody(op, rewriter, firstArgs, {b.i32_val(0)}, result);
+        cloneTileBody(op, rewriter, firstArgs, {b.i32_val(0)}, result);
     scatterTiles(rewriter, loc, firstTiles, b.i32_val(0), vectorSize,
                  tensorAccPtrs, tensorElemTys);
 
@@ -363,7 +362,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         buildDynamicChunkedArgs(op, adaptor, rewriter, tileOffset, vectorSize);
     Value tileResult = loopAcc;
     auto loopTiles =
-        emitTileBody(op, rewriter, tileArgs, {tileOffset}, tileResult);
+        cloneTileBody(op, rewriter, tileArgs, {tileOffset}, tileResult);
     scatterTiles(rewriter, loc, loopTiles, tileOffset, vectorSize,
                  tensorAccPtrs, tensorElemTys);
     Value nextI = LLVM::AddOp::create(rewriter, loc, loopI, b.i32_val(1));

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -378,7 +378,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       ConversionPatternRewriter &rewriter, Location loc, int32_t numChunks,
       int32_t tileSize,
       llvm::function_ref<void(Value /*loopI*/, Value /*dimTileOffset*/,
-                              Block * /*loopHeader*/, Block * /*afterBlock*/)>
+                              Block * /*afterBlock*/)>
           bodyFn) const {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -405,7 +405,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     rewriter.setInsertionPointToEnd(loopBody);
 
     Value tileOffset = b.mul(loopI, b.i32_val(tileSize));
-    bodyFn(loopI, tileOffset, loopHeader, afterBlock);
+    bodyFn(loopI, tileOffset, afterBlock);
 
     Value nextI = LLVM::AddOp::create(rewriter, loc, loopI, b.i32_val(1));
     LLVM::BrOp::create(rewriter, loc, ValueRange{nextI}, loopHeader);
@@ -487,8 +487,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     emitSingleLoop(
         rewriter, loc, numChunks, tileShape[dim],
-        [&](Value loopI, Value dimTileOffset, Block *loopHeader,
-            Block *afterBlock) {
+        [&](Value loopI, Value dimTileOffset, Block *afterBlock) {
           accOffsets.push_back(dimTileOffset);
           Value newFlat =
               LLVM::AddOp::create(rewriter, loc, flatElemOffset,

--- a/test/Conversion/generic-op-loops.mlir
+++ b/test/Conversion/generic-op-loops.mlir
@@ -1,0 +1,90 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-cpu-to-llvm | FileCheck %s
+
+// COM: Verify that emitNestedLoops emits exactly one LLVM loop level per block
+// COM: dimension, rather than a single flat loop with div/mod index arithmetic.
+// COM: Each test scales a block-shaped tensor by a scalar and checks that the
+// COM: number of llvm.cond_br ops in the output matches the block rank.
+
+// -----
+
+// COM: Rank-1 block [16] with tile [4] → 4 iterations, 1 loop level.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [1], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
+  // CHECK-LABEL: @scale_1d
+  // CHECK-COUNT-1: llvm.cond_br
+  // CHECK-NOT: llvm.cond_br
+  tt.func public @scale_1d(%scale: f32) {
+    %0 = ttc.generic %scale attributes {blockShape = array<i32: 16>, tileShape = array<i32: 4>} body {
+      ^bb0(%offset: i32, %s: f32):
+        %cst = arith.constant dense<1.0> : tensor<4xf32, #blocked>
+        %splat = tt.splat %s : f32 -> tensor<4xf32, #blocked>
+        %result = arith.mulf %cst, %splat : tensor<4xf32, #blocked>
+        ttc.yield %result : tensor<4xf32, #blocked>
+    } combiners {} : (f32) -> tensor<16xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Rank-2 block [4, 8] with tile [1, 4] → 4×2 iterations, 2 loop levels.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
+  // CHECK-LABEL: @scale_2d
+  // CHECK-COUNT-2: llvm.cond_br
+  // CHECK-NOT: llvm.cond_br
+  tt.func public @scale_2d(%scale: f32) {
+    %0 = ttc.generic %scale attributes {blockShape = array<i32: 4, 8>, tileShape = array<i32: 1, 4>} body {
+      ^bb0(%dim0: i32, %dim1: i32, %s: f32):
+        %cst = arith.constant dense<1.0> : tensor<1x4xf32, #blocked>
+        %splat = tt.splat %s : f32 -> tensor<1x4xf32, #blocked>
+        %result = arith.mulf %cst, %splat : tensor<1x4xf32, #blocked>
+        ttc.yield %result : tensor<1x4xf32, #blocked>
+    } combiners {} : (f32) -> tensor<4x8xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Rank-3 block [4, 4, 8] with tile [1, 1, 4] → 4×4×2 iterations, 3 loop levels.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1, 4], threadsPerWarp = [1, 1, 1], warpsPerCTA = [1, 1, 1], order = [2, 1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
+  // CHECK-LABEL: @scale_3d
+  // CHECK-COUNT-3: llvm.cond_br
+  // CHECK-NOT: llvm.cond_br
+  tt.func public @scale_3d(%scale: f32) {
+    %0 = ttc.generic %scale attributes {blockShape = array<i32: 4, 4, 8>, tileShape = array<i32: 1, 1, 4>} body {
+      ^bb0(%dim0: i32, %dim1: i32, %dim2: i32, %s: f32):
+        %cst = arith.constant dense<1.0> : tensor<1x1x4xf32, #blocked>
+        %splat = tt.splat %s : f32 -> tensor<1x1x4xf32, #blocked>
+        %result = arith.mulf %cst, %splat : tensor<1x1x4xf32, #blocked>
+        ttc.yield %result : tensor<1x1x4xf32, #blocked>
+    } combiners {} : (f32) -> tensor<4x4x8xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Rank-4 block [2, 2, 4, 8] with tile [1, 1, 1, 4] → 2×2×4×2 iterations, 4 loop levels.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1, 4], threadsPerWarp = [1, 1, 1, 1], warpsPerCTA = [1, 1, 1, 1], order = [3, 2, 1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
+  // CHECK-LABEL: @scale_4d
+  // CHECK-COUNT-4: llvm.cond_br
+  // CHECK-NOT: llvm.cond_br
+  tt.func public @scale_4d(%scale: f32) {
+    %0 = ttc.generic %scale attributes {blockShape = array<i32: 2, 2, 4, 8>, tileShape = array<i32: 1, 1, 1, 4>} body {
+      ^bb0(%dim0: i32, %dim1: i32, %dim2: i32, %dim3: i32, %s: f32):
+        %cst = arith.constant dense<1.0> : tensor<1x1x1x4xf32, #blocked>
+        %splat = tt.splat %s : f32 -> tensor<1x1x1x4xf32, #blocked>
+        %result = arith.mulf %cst, %splat : tensor<1x1x1x4xf32, #blocked>
+        ttc.yield %result : tensor<1x1x1x4xf32, #blocked>
+    } combiners {} : (f32) -> tensor<2x2x4x8xf32, #blocked>
+    tt.return
+  }
+}


### PR DESCRIPTION
Replaces the single flat loop (with div/mod arithmetic to recover per-dimension tile indices) with one LLVM loop level per block dimension. Each loop carries its own induction variable directly, eliminating the index decomposition and producing loop structure that LLVM LICM can reason about.

Adds emitSingleLoop (one loop level with a bodyFn callback) and emitNestedLoops (recursive dispatch, inlining the body region at the innermost level). The unrolled and reduction paths are unchanged.