### PR TITLE
[GenericOp] Make block shape an operand instead of an attribute

### DIFF
--- a/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
+++ b/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
@@ -162,7 +162,7 @@ def TTC_YieldOp : TTC_Op<"yield", [Terminator, ReturnLike, HasParent<"GenericOp"
   let assemblyFormat = "($values^ `:` type($values))? attr-dict";
 }
 
-def TTC_GenericOp : TTC_Op<"generic", [RecursiveMemoryEffects, RecursivelySpeculatable, IsolatedFromAbove]> {
+def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemoryEffects, RecursivelySpeculatable, IsolatedFromAbove]> {
   let summary = "Tiled iteration over a tensor block with fused tensor operations";
 
   let description = [{
@@ -231,7 +231,7 @@ def TTC_GenericOp : TTC_Op<"generic", [RecursiveMemoryEffects, RecursivelySpecul
   let arguments = (ins
     Variadic<TT_Type>:$ins,
 
-    DenseI32ArrayAttr:$blockShape,
+    Variadic<I32>:$blockShape,
     DenseI32ArrayAttr:$tileShape
   );
 
@@ -242,7 +242,7 @@ def TTC_GenericOp : TTC_Op<"generic", [RecursiveMemoryEffects, RecursivelySpecul
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $ins attr-dict-with-keyword `body` $body `combiners` $combiners `:` functional-type(operands, results)
+    `(` $ins `)` `blocks` `[` $blockShape `:` type($blockShape) `]` attr-dict-with-keyword `body` $body `combiners` $combiners `:` functional-type($ins, $results)
   }];
 
   let extraClassDeclaration = [{

--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -25,7 +25,7 @@ LogicalResult GenericOp::verify() {
   auto blockShape = getBlockShape();
   auto tileShape = getTileShape();
 
-  if (blockShape.size() < 1)
+  if (blockShape.empty())
     return emitOpError("must provide a non-empty block/tile shape");
 
   if (blockShape.size() != tileShape.size()) {
@@ -33,24 +33,28 @@ LogicalResult GenericOp::verify() {
                "expects blockShape and tileShape to have the same rank, got ")
            << blockShape.size() << " vs " << tileShape.size();
   }
-  for (unsigned i = 0; i < blockShape.size(); i++) {
-    if (blockShape[i] <= 0) {
-      return emitOpError("expects blockShape[")
-             << i << "] to be positive, got " << blockShape[i];
-    }
+  for (unsigned i = 0; i < tileShape.size(); i++) {
     if (tileShape[i] <= 0) {
       return emitOpError("expects tileShape[")
              << i << "] to be positive, got " << tileShape[i];
     }
-    if (blockShape[i] < tileShape[i]) {
-      return emitOpError("expects blockShape[")
-             << i << "] >= tileShape[" << i << "], got " << blockShape[i]
-             << " vs " << tileShape[i];
-    }
-    if (blockShape[i] % tileShape[i] != 0) {
-      return emitOpError("expects blockShape[")
-             << i << "] % tileShape[" << i << "] == 0, got " << blockShape[i]
-             << " vs " << tileShape[i];
+
+    // blockShape[i] is a runtime value; check constraints only when it folds
+    // to a constant (e.g. when constructed from arith.constant).
+    APInt blockVal;
+    if (matchPattern(blockShape[i], m_ConstantInt(&blockVal))) {
+      int64_t bv = blockVal.getSExtValue();
+      if (bv <= 0)
+        return emitOpError("expects blockShape[")
+               << i << "] to be positive, got " << bv;
+      if (bv < tileShape[i])
+        return emitOpError("expects blockShape[")
+               << i << "] >= tileShape[" << i << "], got " << bv << " vs "
+               << tileShape[i];
+      if (bv % tileShape[i] != 0)
+        return emitOpError("expects blockShape[")
+               << i << "] % tileShape[" << i << "] == 0, got " << bv << " vs "
+               << tileShape[i];
     }
   }
 

--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -55,6 +55,10 @@ LogicalResult GenericOp::verify() {
         return emitOpError("expects blockShape[")
                << i << "] % tileShape[" << i << "] == 0, got " << bv << " vs "
                << tileShape[i];
+    } else {
+      return emitOpError("only constant block shapes are currently supported "
+                         "for verification, got ")
+             << blockShape[i];
     }
   }
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -103,10 +103,16 @@ struct WrapStores : public mlir::OpRewritePattern<triton::StoreOp> {
 
     SmallVector<Value> insValues =
         llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
+    SmallVector<Value> blockShapeValues =
+        llvm::map_to_vector(blockShape, [&](int32_t s) {
+          return arith::ConstantOp::create(rewriter, loc,
+                                           rewriter.getI32IntegerAttr(s))
+              .getResult();
+        });
 
     auto generic =
         cpu::GenericOp::create(rewriter, loc, /*resultTypes=*/TypeRange{},
-                               insValues, blockShape, tileShape);
+                               insValues, blockShapeValues, tileShape);
 
     IRMapping bodyMapping;
     initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
@@ -176,8 +182,14 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
 
     SmallVector<Value> insValues =
         llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
+    SmallVector<Value> blockShapeValues =
+        llvm::map_to_vector(blockShape, [&](int32_t s) {
+          return arith::ConstantOp::create(rewriter, loc,
+                                           rewriter.getI32IntegerAttr(s))
+              .getResult();
+        });
     auto generic = cpu::GenericOp::create(rewriter, loc, resultTypes, insValues,
-                                          blockShape, tileShape);
+                                          blockShapeValues, tileShape);
 
     IRMapping bodyMapping;
     initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
@@ -454,8 +466,15 @@ struct WrapKLoopWithDotOp : public mlir::OpRewritePattern<scf::ForOp> {
     SmallVector<Value> insValues =
         llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
 
-    auto generic = cpu::GenericOp::create(rewriter, loc, TypeRange{resultTy},
-                                          insValues, blockShape, tileShape);
+    SmallVector<Value> blockShapeValues =
+        llvm::map_to_vector(blockShape, [&](int32_t s) {
+          return arith::ConstantOp::create(rewriter, loc,
+                                           rewriter.getI32IntegerAttr(s))
+              .getResult();
+        });
+    auto generic =
+        cpu::GenericOp::create(rewriter, loc, TypeRange{resultTy}, insValues,
+                               blockShapeValues, tileShape);
 
     IRMapping bodyMapping;
     initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
@@ -597,12 +616,18 @@ struct WrapConvertLayoutOp
     for (auto value : cvtOp->getOperands()) {
       ins.push_back(TiledInput{value, tileShape});
     }
+
     SmallVector<Value> insValues =
         llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
-
+    SmallVector<Value> blockShapeValues =
+        llvm::map_to_vector(blockShape, [&](int32_t s) {
+          return arith::ConstantOp::create(rewriter, loc,
+                                           rewriter.getI32IntegerAttr(s))
+              .getResult();
+        });
     auto generic = cpu::GenericOp::create(
         rewriter, loc, /*resultTypes=*/TypeRange{convertedTensorTy}, insValues,
-        blockShape, tileShape);
+        blockShapeValues, tileShape);
 
     IRMapping bodyMapping;
     initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -49,6 +49,16 @@ getBlockAndTileShapes(RankedTensorType tensorTy,
   return {blockShape, tileShape};
 }
 
+static SmallVector<Value>
+buildBlockShapeValues(Location loc, ArrayRef<int32_t> blockShape,
+                      mlir::PatternRewriter &rewriter) {
+  return llvm::map_to_vector(blockShape, [&](int32_t s) {
+    return arith::ConstantOp::create(rewriter, loc,
+                                     rewriter.getI32IntegerAttr(s))
+        .getResult();
+  });
+}
+
 struct TiledInput {
   Value value;
   SmallVector<int32_t> shape;
@@ -104,11 +114,7 @@ struct WrapStores : public mlir::OpRewritePattern<triton::StoreOp> {
     SmallVector<Value> insValues =
         llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
     SmallVector<Value> blockShapeValues =
-        llvm::map_to_vector(blockShape, [&](int32_t s) {
-          return arith::ConstantOp::create(rewriter, loc,
-                                           rewriter.getI32IntegerAttr(s))
-              .getResult();
-        });
+        buildBlockShapeValues(loc, blockShape, rewriter);
 
     auto generic =
         cpu::GenericOp::create(rewriter, loc, /*resultTypes=*/TypeRange{},
@@ -183,11 +189,7 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
     SmallVector<Value> insValues =
         llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
     SmallVector<Value> blockShapeValues =
-        llvm::map_to_vector(blockShape, [&](int32_t s) {
-          return arith::ConstantOp::create(rewriter, loc,
-                                           rewriter.getI32IntegerAttr(s))
-              .getResult();
-        });
+        buildBlockShapeValues(loc, blockShape, rewriter);
     auto generic = cpu::GenericOp::create(rewriter, loc, resultTypes, insValues,
                                           blockShapeValues, tileShape);
 
@@ -467,11 +469,7 @@ struct WrapKLoopWithDotOp : public mlir::OpRewritePattern<scf::ForOp> {
         llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
 
     SmallVector<Value> blockShapeValues =
-        llvm::map_to_vector(blockShape, [&](int32_t s) {
-          return arith::ConstantOp::create(rewriter, loc,
-                                           rewriter.getI32IntegerAttr(s))
-              .getResult();
-        });
+        buildBlockShapeValues(loc, blockShape, rewriter);
     auto generic =
         cpu::GenericOp::create(rewriter, loc, TypeRange{resultTy}, insValues,
                                blockShapeValues, tileShape);
@@ -620,11 +618,7 @@ struct WrapConvertLayoutOp
     SmallVector<Value> insValues =
         llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
     SmallVector<Value> blockShapeValues =
-        llvm::map_to_vector(blockShape, [&](int32_t s) {
-          return arith::ConstantOp::create(rewriter, loc,
-                                           rewriter.getI32IntegerAttr(s))
-              .getResult();
-        });
+        buildBlockShapeValues(loc, blockShape, rewriter);
     auto generic = cpu::GenericOp::create(
         rewriter, loc, /*resultTypes=*/TypeRange{convertedTensorTy}, insValues,
         blockShapeValues, tileShape);

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -58,7 +58,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     for (auto [opIdx, origArg, llvmArg] : llvm::enumerate(
              body->getArguments().drop_front(op.getNumInductionVars()),
-             adaptor.getOperands())) {
+             adaptor.getIns())) {
       LDBG("Chunk operand " << opIdx << " = " << origArg << " --> " << llvmArg);
       if (!isa<RankedTensorType>(origArg.getType())) {
         // forward constants and scalars without chunking
@@ -224,7 +224,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     for (auto [opIdx, origArg, llvmArg] : llvm::enumerate(
              body->getArguments().drop_front(op.getNumInductionVars()),
-             adaptor.getOperands())) {
+             adaptor.getIns())) {
       if (Value ptrArg = getGenericOutputTensorAsPtr(op, opIdx, llvmArg)) {
         // Load this tile's elements from the alloca produced by the prior
         // generic and pack them into the tile struct.
@@ -505,15 +505,19 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
 
-    auto blockShapeAttr = op->getAttrOfType<DenseI32ArrayAttr>("blockShape");
-    assert(blockShapeAttr &&
-           "expected generic op to have blockShape attribute");
     auto tileShapeAttr = op->getAttrOfType<DenseI32ArrayAttr>("tileShape");
     assert(tileShapeAttr && "expected generic op to have tileShape attribute");
-
-    ArrayRef<int32_t> blockShape = blockShapeAttr.asArrayRef();
     ArrayRef<int32_t> tileShape = tileShapeAttr.asArrayRef();
-    assert(blockShape.size() == tileShape.size() && !blockShape.empty() &&
+
+    SmallVector<int32_t> blockShape;
+    for (Value dim : op.getBlockShape()) {
+      APInt val;
+      assert(matchPattern(dim, m_ConstantInt(&val)) &&
+             "expected blockShape operand to fold to a constant integer");
+      blockShape.push_back(static_cast<int32_t>(val.getSExtValue()));
+    }
+
+    assert(!blockShape.empty() && blockShape.size() == tileShape.size() &&
            "blockShape and tileShape must be non-empty and of the same size");
 
     unsigned vectorSize = 1, numChunks = 1;
@@ -588,7 +592,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     const bool requiresTensorArgMaterialization = llvm::any_of(
         llvm::enumerate(
             llvm::zip(body->getArguments().drop_front(op.getNumInductionVars()),
-                      adaptor.getOperands())),
+                      adaptor.getIns())),
         [this, &op](auto pair) {
           auto [opIdx, argPair] = pair;
           auto [origArg, llvmArg] = argPair;

--- a/test/Analysis/axis-info-generic.mlir
+++ b/test/Analysis/axis-info-generic.mlir
@@ -17,7 +17,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
         %x_3 = tt.addptr %x, %offsets_1 : tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xi32, #blocked>
 
         // CHECK-COUNT-128: ttc.masked_load {{.*}} -> vector<4xf32>
-        ttc.generic %x_3 attributes {blockShape = array<i32: 512>, tileShape = array<i32: 4>} body {
+        ttc.generic (%x_3) blocks [%c512_i32 : i32] attributes {tileShape = array<i32: 4>} body {
             ^bb0(%offset:i32, %arg0: tensor<4x!tt.ptr<f32>, #blocked>):
                 %x_10 = tt.load %arg0 : tensor<4x!tt.ptr<f32>, #blocked>
                 ttc.yield
@@ -31,7 +31,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [1], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
     tt.func public @load_scalar(%x_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
-        ttc.generic %x_ptr attributes {blockShape = array<i32: 1024>, tileShape = array<i32: 4>} body {
+        %c1024_i32 = arith.constant 1024 : i32
+        ttc.generic (%x_ptr) blocks [%c1024_i32 : i32] attributes {tileShape = array<i32: 4>} body {
             ^bb0(%tileOffset: i32, %ptr: !tt.ptr<f32>):
                 %offsets = ttc.make_dynamic_range %tileOffset : tensor<4xi32, #blocked>
                 %ptrs = tt.splat %ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>, #blocked>
@@ -66,9 +67,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // 4 M-tiles × 1 N-tile = 4 body invocations, each must emit one vector<8xf16> store.
     // CHECK-COUNT-4: ttc.masked_store {{.*}} : (!llvm.ptr<1>, vector<8xf16>, vector<8xi1>) -> ()
     // CHECK-NOT: ttc.masked_store {{.*}} : (!llvm.ptr<1>, vector<1xf16>
-    ttc.generic %data, %c_ptr, %stride_cm, %M, %N, %offs_am, %offs_bn
-        attributes {blockShape = array<i32: 4, 8>, tileShape = array<i32: 1, 8>} body {
-    ^bb0(%tile_n: i32, %tile_m: i32,
+    %c4_i32 = arith.constant 4 : i32
+    %c8_i32 = arith.constant 8 : i32
+    ttc.generic (%data, %c_ptr, %stride_cm, %M, %N, %offs_am, %offs_bn) blocks
+        [%c4_i32, %c8_i32 : i32, i32] attributes {tileShape = array<i32: 1, 8>} body {
+    ^bb0(%tile_m: i32, %tile_n: i32,
          %tile_data: tensor<1x8xf16, #blocked>,
          %ptr: !tt.ptr<f16>, %stride: i32, %m_bound: i32, %n_bound: i32,
          %row_base: i32, %col_base: i32):

--- a/test/Conversion/generic-op-loops.mlir
+++ b/test/Conversion/generic-op-loops.mlir
@@ -15,7 +15,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-COUNT-1: llvm.cond_br
   // CHECK-NOT: llvm.cond_br
   tt.func public @scale_1d(%scale: f32) {
-    %0 = ttc.generic %scale attributes {blockShape = array<i32: 16>, tileShape = array<i32: 4>} body {
+    %c16_i32 = arith.constant 16 : i32
+
+    %0 = ttc.generic (%scale) blocks [%c16_i32 : i32] attributes {tileShape = array<i32: 4>} body {
       ^bb0(%offset: i32, %s: f32):
         %cst = arith.constant dense<1.0> : tensor<4xf32, #blocked>
         %splat = tt.splat %s : f32 -> tensor<4xf32, #blocked>
@@ -36,7 +38,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-COUNT-2: llvm.cond_br
   // CHECK-NOT: llvm.cond_br
   tt.func public @scale_2d(%scale: f32) {
-    %0 = ttc.generic %scale attributes {blockShape = array<i32: 4, 8>, tileShape = array<i32: 1, 4>} body {
+    %c4_i32 = arith.constant 4 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = ttc.generic (%scale) blocks [%c4_i32, %c8_i32 : i32, i32] attributes {tileShape = array<i32: 1, 4>} body {
       ^bb0(%dim0: i32, %dim1: i32, %s: f32):
         %cst = arith.constant dense<1.0> : tensor<1x4xf32, #blocked>
         %splat = tt.splat %s : f32 -> tensor<1x4xf32, #blocked>
@@ -57,7 +61,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-COUNT-3: llvm.cond_br
   // CHECK-NOT: llvm.cond_br
   tt.func public @scale_3d(%scale: f32) {
-    %0 = ttc.generic %scale attributes {blockShape = array<i32: 4, 4, 8>, tileShape = array<i32: 1, 1, 4>} body {
+    %c4_i32 = arith.constant 4 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = ttc.generic (%scale) blocks [%c4_i32, %c4_i32, %c8_i32 : i32, i32, i32] attributes {tileShape = array<i32: 1, 1, 4>} body {
       ^bb0(%dim0: i32, %dim1: i32, %dim2: i32, %s: f32):
         %cst = arith.constant dense<1.0> : tensor<1x1x4xf32, #blocked>
         %splat = tt.splat %s : f32 -> tensor<1x1x4xf32, #blocked>
@@ -78,7 +84,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-COUNT-4: llvm.cond_br
   // CHECK-NOT: llvm.cond_br
   tt.func public @scale_4d(%scale: f32) {
-    %0 = ttc.generic %scale attributes {blockShape = array<i32: 2, 2, 4, 8>, tileShape = array<i32: 1, 1, 1, 4>} body {
+    %c2_i32 = arith.constant 2 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = ttc.generic (%scale) blocks [%c2_i32, %c2_i32, %c4_i32, %c8_i32 : i32, i32, i32, i32] attributes {tileShape = array<i32: 1, 1, 1, 4>} body {
       ^bb0(%dim0: i32, %dim1: i32, %dim2: i32, %dim3: i32, %s: f32):
         %cst = arith.constant dense<1.0> : tensor<1x1x1x4xf32, #blocked>
         %splat = tt.splat %s : f32 -> tensor<1x1x1x4xf32, #blocked>


### PR DESCRIPTION
Allows us to create generics over runtime values if we are using dynamic loops.

(conflicts with #382 - will land that one first then rebase) 