### PR TITLE
Overhaul `convert_layout` op handling in Tile and Fuse

### DIFF
--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -792,6 +792,25 @@ struct FuseMakeRangeIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
         auto newResultType = updateTensorType(resultType, tileShape);
         auto sliceEncodingAttr =
             dyn_cast<triton::gpu::SliceEncodingAttr>(resultType.getEncoding());
+        if (!sliceEncodingAttr) {
+          // check to see if a slice encoding attr exists downstream from a cvt
+          // op that was previously rematerialized
+          ForwardSliceOptions fwdOpt;
+          fwdOpt.filter = [&](Operation *op) {
+            auto cvtInSlice = dyn_cast<gpu::ConvertLayoutOp>(op);
+            if (cvtInSlice) {
+              auto localSliceEncodingAttr = dyn_cast<gpu::SliceEncodingAttr>(
+                  cast<RankedTensorType>(cvtInSlice.getType()).getEncoding());
+              if (localSliceEncodingAttr) {
+                sliceEncodingAttr = localSliceEncodingAttr;
+                return false;
+              }
+            }
+            return true;
+          };
+          SetVector<Operation *> slice;
+          getForwardSlice(blockArg, &slice, fwdOpt);
+        }
         unsigned dim;
         if (!sliceEncodingAttr) {
           assert(rank == 1 && "make dynamic range op without slice encoding "

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -61,6 +61,35 @@ buildBlockShapeValues(Location loc, ArrayRef<int32_t> blockShape,
   });
 }
 
+// Note: this helper assumes the conversion only involves reordering of
+// registers
+static std::optional<SmallVector<int32_t>>
+getBlockedRegisterConversionTileShape(RankedTensorType srcTy,
+                                      RankedTensorType dstTy) {
+  // only support blocked -> blocked conversions
+  auto srcEnc = dyn_cast<gpu::BlockedEncodingAttr>(srcTy.getEncoding());
+  auto dstEnc = dyn_cast<gpu::BlockedEncodingAttr>(dstTy.getEncoding());
+  if (!srcEnc || !dstEnc)
+    return std::nullopt;
+
+  auto srcSPT = srcEnc.getSizePerThread();
+  auto dstSPT = dstEnc.getSizePerThread();
+  assert(srcSPT.size() == dstSPT.size());
+
+  auto shape = srcTy.getShape();
+  SmallVector<int32_t> tileShape;
+
+  for (auto [s, d, dimSize] : llvm::zip(srcSPT, dstSPT, shape)) {
+    int32_t tile = std::lcm((int32_t)s, (int32_t)d);
+    // Tile must evenly divide the tensor dimension
+    if (dimSize % tile != 0)
+      return std::nullopt;
+    tileShape.push_back(tile);
+  }
+
+  return tileShape;
+}
+
 struct TiledInput {
   Value value;
   SmallVector<int32_t> shape;
@@ -991,21 +1020,43 @@ struct FuseConvertLayoutOpIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
 
       LDBG("Evaluate cvt for fusion: " << cvtOp);
       auto srcTy = cast<RankedTensorType>(cvtOp.getSrc().getType());
+      auto dstTy = cast<RankedTensorType>(cvtOp.getType());
 
-      auto layout =
-          minimalCvtLayout(srcTy, cast<RankedTensorType>(cvtOp.getType()));
-      auto outDims = to_vector(layout.getOutDimNames());
-
-      // TODO: to start, let's just fuse the no-op CVTs
-      if (!outDims.empty()) {
-        LDBG("Not fusing cvt due to non-empty layout: " << layout);
-        continue;
-      }
-
+      // get the existing tile type
       BlockArgument blockArg = body->getArgument(numIV + i);
       auto tiledType = cast<RankedTensorType>(blockArg.getType());
 
       SmallVector<int32_t> tileShape(tiledType.getShape());
+
+      // determine if the register shuffle required fits inside our generic
+      // Note: the logic here is very similar to cvtReordersRegisters
+      auto layout = minimalCvtLayout(srcTy, dstTy);
+      auto outDims = to_vector(layout.getOutDimNames());
+
+      if (!outDims.empty()) {
+        MLIRContext *ctx = srcTy.getContext();
+        auto kRegister = StringAttr::get(ctx, "register");
+
+        // layout must only reorder registers
+        if (ArrayRef(outDims) != ArrayRef({kRegister}))
+          continue;
+
+        // must be able to determine the required tile shape and it must fit
+        // inside this generic
+        auto requiredTileShape =
+            getBlockedRegisterConversionTileShape(srcTy, dstTy);
+        if (!requiredTileShape)
+          continue;
+
+        auto required = *requiredTileShape;
+        bool fits = llvm::all_of(llvm::zip(tileShape, required), [](auto pair) {
+          auto [cur, req] = pair;
+          return cur % req == 0;
+        });
+        if (!fits)
+          continue;
+      }
+
       SmallVector<Value> newIns(genericOp.getIns());
 
       IRMapping mapping;
@@ -1018,7 +1069,7 @@ struct FuseConvertLayoutOpIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
       // 2. clone
       rewriter.setInsertionPointToStart(body);
       Operation *newOp = rewriter.clone(*op, mapping);
-      newOp->getResult(0).setType(updateTensorType(cvtOp.getType(), tileShape));
+      newOp->getResult(0).setType(updateTensorType(dstTy, tileShape));
 
       // 3. replace block arg and clean up
       blockArg.replaceAllUsesWith(newOp->getResult(0));

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -1043,6 +1043,7 @@ struct FuseConvertLayoutOpIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
       auto outDims = to_vector(layout.getOutDimNames());
 
       if (!outDims.empty()) {
+        LDBG("Non-empty out dims, layout: " << layout);
         MLIRContext *ctx = srcTy.getContext();
         auto kRegister = StringAttr::get(ctx, "register");
 
@@ -1064,6 +1065,8 @@ struct FuseConvertLayoutOpIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
         });
         if (!fits)
           continue;
+
+        LDBG("Cvt can be legally fused");
       }
 
       SmallVector<Value> newIns(genericOp.getIns());

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -638,7 +638,6 @@ struct WrapConvertLayoutOp
     if (!requiredTileShape)
       return failure();
 
-    SmallVector<int32_t> tileShape = *requiredTileShape;
     // Use the destination ty to get the tile shape. the destination ty will be
     // tiled in any cvt evaluated for fusion, so we want to use the same
     // criteria for "fits" to avoid wrapping fusible cvts
@@ -646,9 +645,10 @@ struct WrapConvertLayoutOp
         dstTy, cast<gpu::BlockedEncodingAttr>(dstTy.getEncoding()));
 
     // return failure as we should be able to fuse this cvt op
-    if (ArrayRef(tileShape) == ArrayRef(defaultTileShape))
+    if (ArrayRef(*requiredTileShape) == ArrayRef(defaultTileShape))
       return failure();
 
+    SmallVector<int32_t> tileShape = blockShape;
     SmallVector<TiledInput> ins;
     for (auto value : cvtOp->getOperands()) {
       ins.push_back(TiledInput{value, tileShape});

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -619,27 +619,35 @@ struct WrapConvertLayoutOp
     if (cvtOp->getParentOfType<cpu::GenericOp>())
       return failure();
 
-    auto operand = cvtOp.getSrc();
+    auto src = cvtOp.getSrc();
+    auto srcTy = cast<RankedTensorType>(src.getType());
+    auto dstTy = cast<RankedTensorType>(cvtOp.getType());
 
-    auto tensorTy = cast<RankedTensorType>(operand.getType());
-    auto encoding = dyn_cast<gpu::BlockedEncodingAttr>(tensorTy.getEncoding());
-    if (!encoding)
+    auto layout = minimalCvtLayout(srcTy, dstTy);
+    auto outDims = to_vector(layout.getOutDimNames());
+    MLIRContext *ctx = srcTy.getContext();
+    auto kRegister = StringAttr::get(ctx, "register");
+    // only wrap cvts that reorder registers. if the cvt does nothing (empty out
+    // dims), return failure as we should be able to fuse it
+    if (outDims.empty() || (ArrayRef(outDims) != ArrayRef({kRegister})))
       return failure();
 
-    // only wrap blocked->blocked conversions
-    auto convertedTensorTy =
-        cast<RankedTensorType>(cvtOp.getResult().getType());
-    if (!isa<triton::gpu::BlockedEncodingAttr>(convertedTensorTy.getEncoding()))
+    //  get blocked register conversion tile shape
+    auto requiredTileShape =
+        getBlockedRegisterConversionTileShape(srcTy, dstTy);
+    if (!requiredTileShape)
       return failure();
 
-    // Note: this uses the source tensor ty to determine the tile shape. if we
-    // tile over the source, we should be able to write to any location in the
-    // output
-    auto [blockShape, tileShape] = getBlockAndTileShapes(tensorTy, encoding);
+    SmallVector<int32_t> tileShape = *requiredTileShape;
+    // Use the destination ty to get the tile shape. the destination ty will be
+    // tiled in any cvt evaluated for fusion, so we want to use the same
+    // criteria for "fits" to avoid wrapping fusible cvts
+    auto [blockShape, defaultTileShape] = getBlockAndTileShapes(
+        dstTy, cast<gpu::BlockedEncodingAttr>(dstTy.getEncoding()));
 
-    // but, overwrite the tileshape to match the block shape (i.e. just generate
-    // a single tile generic for now)
-    tileShape = blockShape;
+    // return failure as we should be able to fuse this cvt op
+    if (ArrayRef(tileShape) == ArrayRef(defaultTileShape))
+      return failure();
 
     SmallVector<TiledInput> ins;
     for (auto value : cvtOp->getOperands()) {
@@ -650,14 +658,15 @@ struct WrapConvertLayoutOp
         llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
     SmallVector<Value> blockShapeValues =
         buildBlockShapeValues(loc, blockShape, rewriter);
-    auto generic = cpu::GenericOp::create(
-        rewriter, loc, /*resultTypes=*/TypeRange{convertedTensorTy}, insValues,
-        blockShapeValues, tileShape);
+    auto generic =
+        cpu::GenericOp::create(rewriter, loc, /*resultTypes=*/TypeRange{dstTy},
+                               insValues, blockShapeValues, tileShape);
 
     IRMapping bodyMapping;
     initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
 
     auto newCvt = rewriter.clone(*cvtOp, bodyMapping);
+    newCvt->getResult(0).setType(updateTensorType(dstTy, tileShape));
     cpu::YieldOp::create(rewriter, loc, newCvt->getResults());
 
     rewriter.replaceOp(cvtOp, generic.getResults());
@@ -1101,7 +1110,7 @@ struct TritonCPUTileAndFusePass
     patterns.add<WrapStores>(context, benefitDefault + 1);
     patterns.add<WrapReduceOp>(context, benefitDefault + 1);
     patterns.add<WrapKLoopWithDotOp>(context, benefitDefault + 1);
-    // patterns.add<WrapConvertLayoutOp>(context, benefitDefault);
+    patterns.add<WrapConvertLayoutOp>(context, benefitDefault);
 
     if (applyPatternsGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -5,6 +5,8 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/Support/Debug.h"
 
+#include "triton/Analysis/Utility.h"
+
 #include "cpu/include/Dialect/TritonCPU/IR/Dialect.h"
 
 #define DEBUG_TYPE "tritoncpu-tile-and-fuse"
@@ -969,6 +971,69 @@ struct FuseExpandDimsIntoGeneric
   }
 };
 
+struct FuseConvertLayoutOpIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
+  using OpRewritePattern<cpu::GenericOp>::OpRewritePattern;
+
+  LogicalResult
+  matchAndRewrite(cpu::GenericOp genericOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    Block *body = &genericOp.getBody().front();
+    unsigned numIV = genericOp.getNumInductionVars();
+
+    for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
+      Operation *op = insVal.getDefiningOp();
+      if (!op)
+        continue;
+
+      auto cvtOp = dyn_cast<gpu::ConvertLayoutOp>(op);
+      if (!cvtOp)
+        continue;
+
+      LDBG("Evaluate cvt for fusion: " << cvtOp);
+      auto srcTy = cast<RankedTensorType>(cvtOp.getSrc().getType());
+
+      auto layout =
+          minimalCvtLayout(srcTy, cast<RankedTensorType>(cvtOp.getType()));
+      auto outDims = to_vector(layout.getOutDimNames());
+
+      // TODO: to start, let's just fuse the no-op CVTs
+      if (!outDims.empty()) {
+        LDBG("Not fusing cvt due to non-empty layout: " << layout);
+        continue;
+      }
+
+      BlockArgument blockArg = body->getArgument(numIV + i);
+      auto tiledType = cast<RankedTensorType>(blockArg.getType());
+
+      SmallVector<int32_t> tileShape(tiledType.getShape());
+      SmallVector<Value> newIns(genericOp.getIns());
+
+      IRMapping mapping;
+      // 1. Add new block args for source op inputs at body end
+      newIns.push_back(cvtOp.getSrc());
+      mapping.map(cvtOp.getSrc(),
+                  body->addArgument(updateTensorType(srcTy, tileShape),
+                                    cvtOp.getSrc().getLoc()));
+
+      // 2. clone
+      rewriter.setInsertionPointToStart(body);
+      Operation *newOp = rewriter.clone(*op, mapping);
+      newOp->getResult(0).setType(updateTensorType(cvtOp.getType(), tileShape));
+
+      // 3. replace block arg and clean up
+      blockArg.replaceAllUsesWith(newOp->getResult(0));
+      body->eraseArgument(numIV + i);
+      newIns.erase(newIns.begin() + i);
+
+      rewriter.modifyOpInPlace(
+          genericOp, [&]() { genericOp.getInsMutable().assign(newIns); });
+
+      return success();
+    }
+    return failure();
+  }
+};
+
 } // namespace
 
 struct TritonCPUTileAndFusePass
@@ -985,7 +1050,7 @@ struct TritonCPUTileAndFusePass
     patterns.add<WrapStores>(context, benefitDefault + 1);
     patterns.add<WrapReduceOp>(context, benefitDefault + 1);
     patterns.add<WrapKLoopWithDotOp>(context, benefitDefault + 1);
-    patterns.add<WrapConvertLayoutOp>(context, benefitDefault);
+    // patterns.add<WrapConvertLayoutOp>(context, benefitDefault);
 
     if (applyPatternsGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();
@@ -999,6 +1064,7 @@ struct TritonCPUTileAndFusePass
     fusePatterns.add<FuseExpandDimsIntoGeneric>(context, benefitDefault);
     fusePatterns.add<FuseMakeRangeIntoGeneric>(context, benefitDefault);
     fusePatterns.add<FuseConstantIntoGeneric>(context, benefitDefault);
+    fusePatterns.add<FuseConvertLayoutOpIntoGeneric>(context, benefitDefault);
 
     if (applyPatternsGreedily(m, std::move(fusePatterns)).failed()) {
       signalPassFailure();

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -7,6 +7,8 @@
 
 #include "triton/Analysis/Utility.h"
 
+#include <numeric>
+
 #include "cpu/include/Dialect/TritonCPU/IR/Dialect.h"
 
 #define DEBUG_TYPE "tritoncpu-tile-and-fuse"

--- a/test/Transform/fuse_cvt.mlir
+++ b/test/Transform/fuse_cvt.mlir
@@ -1,0 +1,84 @@
+// RUN: triton-opt %s -split-input-file --tritoncpu-tile-and-fuse | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
+  // CHECK-LABEL: tt.func public @test_fuse_trivial_cvt
+  tt.func public @test_fuse_trivial_cvt(%ptr: !tt.ptr<f16>) attributes {noinline = false, ttc.persistent_kernel} {
+    %c1 = arith.constant 1 : i32
+    %start = ttc.block_start
+    %end = ttc.block_end
+    scf.for %bid = %start to %end step %c1 : i32 {
+      %block = ttc.current_block %bid : i32
+      %cst = arith.constant dense<0.0> : tensor<4x8xf16, #blocked1>
+      %ptrs = tt.splat %ptr : !tt.ptr<f16> -> tensor<4x8x!tt.ptr<f16>, #blocked>
+      // CHECK: ttc.generic
+      // CHECK ttg.convert_layout
+      // CHECK: tt.store
+      // CHECK-NOT: ttc.generic
+      %cvt = ttg.convert_layout %cst : tensor<4x8xf16, #blocked1> -> tensor<4x8xf16, #blocked>
+      tt.store %ptrs, %cvt : tensor<4x8x!tt.ptr<f16>, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// Register-reordering CVT where requiredTileShape == dst sizePerThread
+// (sizePerThread=[1,4] → [1,8], lcm=[1,8]) is fusible
+//
+
+
+#src = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#dst = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
+  // CHECK-LABEL: tt.func public @test_fuse_register_cvt
+  tt.func public @test_fuse_register_cvt(%ptr: !tt.ptr<f16>) attributes {noinline = false, ttc.persistent_kernel} {
+    %c1 = arith.constant 1 : i32
+    %start = ttc.block_start
+    %end = ttc.block_end
+    scf.for %bid = %start to %end step %c1 : i32 {
+    // CHECK:       ttc.generic
+    // CHECK:         ttg.convert_layout
+    // CHECK:         tt.store
+    // CHECK-NOT:   ttc.generic
+      %block = ttc.current_block %bid : i32
+      %cst = arith.constant dense<0.0> : tensor<16x8xf16, #src>
+      %ptrs = tt.splat %ptr : !tt.ptr<f16> -> tensor<16x8x!tt.ptr<f16>, #dst>
+      %cvt = ttg.convert_layout %cst : tensor<16x8xf16, #src> -> tensor<16x8xf16, #dst>
+      tt.store %ptrs, %cvt : tensor<16x8x!tt.ptr<f16>, #dst>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// Non-fusible register-reordering CVT (sizePerThread=[4,4] → [1,8],
+// requiredTileShape=[4,8] ≠ defaultTileShape=[1,8]) gets wrapped in its own
+// generic; the store gets a separate generic.
+
+#blocked2 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
+  // CHECK-LABEL: tt.func public @test_wrap_nonfusible_cvt
+  tt.func public @test_wrap_nonfusible_cvt(%ptr: !tt.ptr<f16>) attributes {noinline = false, ttc.persistent_kernel} {
+    %c1 = arith.constant 1 : i32
+    %start = ttc.block_start
+    %end = ttc.block_end
+    scf.for %bid = %start to %end step %c1 : i32 {
+
+      %block = ttc.current_block %bid : i32
+      %cst = arith.constant dense<0.0> : tensor<16x32xf16, #blocked2>
+      %ptrs = tt.splat %ptr : !tt.ptr<f16> -> tensor<16x32x!tt.ptr<f16>, #blocked3>
+      // CHECK:       ttc.generic
+      // CHECK:         ttg.convert_layout
+      // CHECK:       ttc.generic
+      // CHECK:         tt.store
+      %cvt = ttg.convert_layout %cst : tensor<16x32xf16, #blocked2> -> tensor<16x32xf16, #blocked3>
+      tt.store %ptrs, %cvt : tensor<16x32x!tt.ptr<f16>, #blocked3>
+    }
+    tt.return
+  }
+}


### PR DESCRIPTION
Upstream recently made CVTs that reorder registers free, meaning they are no longer rematerialized. This breaks the TileAndFuse pass in two ways:

Many more CVTs now get wrapped into generic ops, which is problematic — trivial CVTs should be fused rather than wrapped, and wrapping can cause illegal nesting.
2. The slice encoding we relied on to determine `make_dynamic_range` dimension is now potentially downstream of the `tt.make_range` op (on a subsequent `convert_layout`), causing incorrect induction variable assignment.

This PR addresses both issues. First, the wrapping logic is tightened to skip CVTs that don't do real work. Second, trivial CVTs — those that only reorder registers and are local to a tile — are fused into the enclosing generic rather than wrapped.

Second, we now fuse convert layout ops, but only if they are trivial - i.e. if they only reorder registers _and_ are also no-ops. 

Note: there is some intentional conservatism here. Ideally, any CVT that fits within the target tile shape should be fuseable, and any that doesn't should get its own generic. We're not fully there yet — and, probably, there's some ambiguity for matmul cases outside of tutorial 3. But, we have that ambiguity anyway since not all matmuls pattern match yet. This fix is scoped to unblock the immediate regression without a larger refactor. Marking as draft pending a decision on whether to tighten or loosen the constraints further before landing. 