### PR TITLE
[GenericOp] Drop `combiners` blocks in favor of `iter_args`

### DIFF
--- a/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
+++ b/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
@@ -187,10 +187,11 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
 
     The `combiners` region contains one block per scalar result. Each block takes
     two arguments `(acc, partial)` of the result type and yields the updated
-    accumulator. The lowering bootstraps the accumulator from the first tile's
-    partial result and applies the combiner for each subsequent tile. The combiners
-    region is only used for scalar reductions. Combining (concatenating) tensor tiles
-    for Generics that output tensors is handled separately by the lowering.
+    accumulator. When `init_vals` is provided, `init_vals[i]` seeds the
+    accumulator for combiner `i` before the first tile; when absent the lowering
+    bootstraps from the first tile's partial result. The combiners region is only
+    used for scalar reductions. Combining (concatenating) tensor tiles for
+    Generics that output tensors is handled separately by the lowering.
 
     Constraints:
     - `blockShape` and `tileShape` must have the same rank.
@@ -230,6 +231,7 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
 
   let arguments = (ins
     Variadic<TT_Type>:$ins,
+    Variadic<AnyType>:$init_vals,
 
     Variadic<I32>:$blockShape,
     DenseI32ArrayAttr:$tileShape
@@ -241,8 +243,14 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
 
   let hasVerifier = 1;
 
+  let builders = [
+    OpBuilder<(ins "TypeRange":$results, "ValueRange":$ins, "ValueRange":$blockShape, "ArrayRef<int32_t>":$tileShape), [{
+      build($_builder, $_state, results, ins, ValueRange(), blockShape, tileShape);
+    }]>
+  ];
+
   let assemblyFormat = [{
-    `(` $ins `)` `blocks` `[` $blockShape `:` type($blockShape) `]` attr-dict-with-keyword `body` $body `combiners` $combiners `:` functional-type($ins, $results)
+    `(` $ins `)` (`init` `(` $init_vals^ `:` type($init_vals) `)`)? `blocks` `[` $blockShape `:` type($blockShape) `]` attr-dict-with-keyword `body` $body `combiners` $combiners `:` functional-type($ins, $results)
   }];
 
   let extraClassDeclaration = [{

--- a/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
+++ b/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
@@ -166,66 +166,91 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
   let summary = "Tiled iteration over a tensor block with fused tensor operations";
 
   let description = [{
-    Wraps a fused chain of tensor operations and owns the schedule for iterating
-    over the block in tiles.
+    Tiled iteration over a block of tensor operations with optional loop-carried
+    iter args for reductions.
 
     The operation logically iterates over `blockShape` in steps of `tileShape`,
-    executing the body region once per tile. This models the pattern of splitting
-    a full-block tensor computation into a loop over sub-vectors, enabling
-    register-pressure-friendly lowering without materializing the entire block
-    at once.
+    executing the `body` region once per tile. This splits a full-block tensor
+    computation into a loop over sub-tiles, enabling register-pressure-friendly
+    lowering without materializing the entire block at once.
 
     Operands:
-    - `ins`: tensor-typed inputs (e.g. pointer tensors for loads and stores).
-      Each operand is sliced to `tileShape` for each tile iteration and passed
-      as the corresponding block argument to the body region.
+    - `init_vals`: initial accumulator values, one per entry in `reductionDims`.
+      Each value seeds the corresponding iter arg before the first tile.
+    - `ins`: inputs visible to each tile iteration (pointer tensors, scalars,
+      etc.). Each tensor operand is sliced to `tileShape` for each tile.
 
-    The `body` region receives block arguments corresponding to the tiled slices
-    of `ins`. It is executed once per tile and terminated by `ttc.yield`. When the op has scalar results,
-    `ttc.yield` returns one partial value per result (e.g. the output of a
-    `tt.reduce` over the tile).
+    Attributes:
+    - `blockShape`: the shape of the full block being iterated (runtime values).
+    - `tileShape`: the shape of each tile (compile-time constants).
+    - `reductionDims`: which blockShape dimensions are reduction dimensions.
+      One iter arg is associated with each reduction dimension.
 
-    The `combiners` region contains one block per scalar result. Each block takes
-    two arguments `(acc, partial)` of the result type and yields the updated
-    accumulator. When `init_vals` is provided, `init_vals[i]` seeds the
-    accumulator for combiner `i` before the first tile; when absent the lowering
-    bootstraps from the first tile's partial result. The combiners region is only
-    used for scalar reductions. Combining (concatenating) tensor tiles for
-    Generics that output tensors is handled separately by the lowering.
+    Body region block argument ordering: `[ivs..., iter_args..., ins_args...]`
+    - `ivs`: one i32 per tile dimension, giving the per-dimension tile offset.
+    - `iter_args`: one value per entry in `reductionDims`, carrying the running
+      accumulator. The i-th iter arg starts at `init_vals[i]` and is updated
+      each tile via the leading values of `ttc.yield`.
+    - `ins_args`: one tiled slice per `ins` operand.
+
+    `ttc.yield` convention:
+    - The first `|reductionDims|` values update the iter args (carried to the
+      next tile iteration).
+    - Any remaining values are tensor tiles that are scattered into the op's
+      tensor results.
+
+    Results:
+    - The first `|reductionDims|` results hold the final iter arg values after
+      all tiles have been processed.
+    - Any additional results are full-block tensors assembled from the
+      per-tile scatter values.
 
     Constraints:
     - `blockShape` and `tileShape` must have the same rank.
     - Each `blockShape[i]` must be a positive multiple of `tileShape[i]`.
-    - `combiners` must have exactly as many blocks as there are scalar results,
-      each with two arguments and one yield of the matching type.
+    - `|init_vals| == |reductionDims|`.
+    - Body block must have `|ivs| + |reductionDims| + |ins|` arguments.
 
-    Example — elementwise chain (no scalar results, empty combiners):
+    Example — elementwise chain (no reductions):
     ```
-    ttc.generic %src_ptrs, %dst_ptrs {blockShape = [128], tileShape = [16]}
-        : tensor<128x!tt.ptr<f32>>, tensor<128x!tt.ptr<f32>>
-    body {
-    ^bb0(%src: tensor<16x!tt.ptr<f32>>, %dst: tensor<16x!tt.ptr<f32>>):
+    ttc.generic (%src_ptrs, %dst_ptrs) blocks [%c128 : i32]
+        {tileShape = array<i32: 16>, reductionDims = array<i32>}
+        body {
+    ^bb0(%iv: i32, %src: tensor<16x!tt.ptr<f32>>, %dst: tensor<16x!tt.ptr<f32>>):
       %v = tt.load %src : tensor<16xf32>
       %w = math.exp %v  : tensor<16xf32>
       tt.store %dst, %w : tensor<16xf32>
       ttc.yield
-    } combiners {}
+    } : (tensor<128x!tt.ptr<f32>>, tensor<128x!tt.ptr<f32>>) -> ()
     ```
 
-    Example — reduction (one scalar result):
+    Example — scalar reduction (softmax max pass):
     ```
-    %max = ttc.generic %ptrs, %mask {blockShape = [128], tileShape = [16]}
-        : tensor<128x!tt.ptr<f32>>, tensor<128xi1> -> f32
-    body {
-    ^bb0(%tptrs: tensor<16x!tt.ptr<f32>>, %tmask: tensor<16xi1>):
-      %tile    = tt.load %tptrs, %tmask : tensor<16xf32>
-      %partial = tt.reduce %tile {max}  : tensor<16xf32> -> f32
-      ttc.yield %partial : f32
-    } combiners {
-    ^bb0(%acc: f32, %partial: f32):
-      %new = arith.maxnumf %acc, %partial : f32
-      ttc.yield %new : f32
-    }
+    %max = ttc.generic (%ptrs, %n_cols) init (%neg_inf : f32)
+        blocks [%c128 : i32]
+        {tileShape = array<i32: 16>, reductionDims = array<i32: 0>}
+        body {
+    ^bb0(%iv: i32, %acc: f32, %tptrs: tensor<16x!tt.ptr<f32>>, %n: i32):
+      %tile    = tt.load %tptrs : tensor<16xf32>
+      %partial = tt.reduce(%tile) {max} : tensor<16xf32> -> f32
+      %new_acc = arith.maxnumf %partial, %acc : f32
+      ttc.yield %new_acc : f32
+    } : (!tt.ptr<f32>, i32) -> f32
+    ```
+
+    Example — mixed scalar + tensor result (softmax sum + exp):
+    ```
+    %sum, %exp_out = ttc.generic (%ptrs, %n_cols) init (%zero : f32)
+        blocks [%c128 : i32]
+        {tileShape = array<i32: 16>, reductionDims = array<i32: 0>}
+        body {
+    ^bb0(%iv: i32, %acc: f32, %tptrs: tensor<16x!tt.ptr<f32>>, %n: i32):
+      %tile    = tt.load %tptrs : tensor<16xf32>
+      %exp     = math.exp %tile : tensor<16xf32>
+      %partial = tt.reduce(%exp) {add} : tensor<16xf32> -> f32
+      %new_acc = arith.addf %partial, %acc : f32
+      ttc.yield %new_acc, %exp : f32, tensor<16xf32>
+    } : (!tt.ptr<f32>, i32) -> (f32, tensor<128xf32>)
     ```
   }];
 
@@ -240,8 +265,7 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
 
   let results = (outs Variadic<AnyType>:$results);
 
-  // TODO: remove combiners once genericoptollvm is updated
-  let regions = (region AnyRegion:$body, AnyRegion:$combiners);
+  let regions = (region AnyRegion:$body);
 
   let hasVerifier = 1;
 
@@ -252,7 +276,7 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
   ];
 
   let assemblyFormat = [{
-    `(` $ins `)` (`init` `(` $init_vals^ `:` type($init_vals) `)`)? `blocks` `[` $blockShape `:` type($blockShape) `]` attr-dict-with-keyword `body` $body `combiners` $combiners `:` functional-type($ins, $results)
+    `(` $ins `)` (`init` `(` $init_vals^ `:` type($init_vals) `)`)? `blocks` `[` $blockShape `:` type($blockShape) `]` attr-dict-with-keyword `body` $body `:` functional-type($ins, $results)
   }];
 
   let extraClassDeclaration = [{

--- a/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
+++ b/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
@@ -230,8 +230,8 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
   }];
 
   let arguments = (ins
-    Variadic<TT_Type>:$ins,
     Variadic<AnyType>:$init_vals,
+    Variadic<TT_Type>:$ins,
 
     Variadic<I32>:$blockShape,
     DenseI32ArrayAttr:$tileShape,
@@ -247,7 +247,7 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
 
   let builders = [
     OpBuilder<(ins "TypeRange":$results, "ValueRange":$ins, "ValueRange":$blockShape, "ArrayRef<int32_t>":$tileShape), [{
-      build($_builder, $_state, results, ins, ValueRange(), blockShape, tileShape, SmallVector<int32_t>{});
+      build($_builder, $_state, results, ValueRange(), ins, blockShape, tileShape, SmallVector<int32_t>{});
     }]>
   ];
 
@@ -263,8 +263,11 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
       return getBody().front().getNumArguments() - getNumInductionVars();
     }
     BlockArgument getIterArg(unsigned i) {
-      return getBody().front().getArgument(
-          getNumInductionVars() + getIns().size() + i);
+      return getBody().front().getArgument(getNumInductionVars() + i);
+    }
+    // Index of the first ins block argument: ivs + iter_args precede ins.
+    unsigned getInsArgOffset() {
+      return getNumInductionVars() + getNumIterArgs();
     }
   }];
 }

--- a/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
+++ b/cpu/include/Dialect/TritonCPU/IR/TritonCPUOps.td
@@ -234,18 +234,20 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
     Variadic<AnyType>:$init_vals,
 
     Variadic<I32>:$blockShape,
-    DenseI32ArrayAttr:$tileShape
+    DenseI32ArrayAttr:$tileShape,
+    DenseI32ArrayAttr:$reductionDims
   );
 
   let results = (outs Variadic<AnyType>:$results);
 
+  // TODO: remove combiners once genericoptollvm is updated
   let regions = (region AnyRegion:$body, AnyRegion:$combiners);
 
   let hasVerifier = 1;
 
   let builders = [
     OpBuilder<(ins "TypeRange":$results, "ValueRange":$ins, "ValueRange":$blockShape, "ArrayRef<int32_t>":$tileShape), [{
-      build($_builder, $_state, results, ins, ValueRange(), blockShape, tileShape);
+      build($_builder, $_state, results, ins, ValueRange(), blockShape, tileShape, SmallVector<int32_t>{});
     }]>
   ];
 
@@ -256,8 +258,13 @@ def TTC_GenericOp : TTC_Op<"generic", [AttrSizedOperandSegments, RecursiveMemory
   let extraClassDeclaration = [{
     Value getTileOffset(unsigned dim) { return getBody().front().getArgument(dim); }
     unsigned getNumInductionVars() { return getBlockShape().size(); }
+    unsigned getNumIterArgs() { return getReductionDims().size(); }
     unsigned getNumRegionIterArgs() {
       return getBody().front().getNumArguments() - getNumInductionVars();
+    }
+    BlockArgument getIterArg(unsigned i) {
+      return getBody().front().getArgument(
+          getNumInductionVars() + getIns().size() + i);
     }
   }];
 }

--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -76,62 +76,65 @@ LogicalResult GenericOp::verify() {
       return emitOpError("body induction variable ") << i << " must be i32";
   }
 
-  // Collect scalar result types for init_vals and combiner validation.
-  SmallVector<Type> scalarResultTypes;
-  for (Value result : getResults())
-    if (!isa<RankedTensorType>(result.getType()))
-      scalarResultTypes.push_back(result.getType());
-
-  // init_vals must be empty when there are no combiners.
+  auto reductionDims = getReductionDims();
   auto initVals = getInitVals();
-  Region &combiners = getCombiners();
-  if (combiners.getBlocks().empty() && !initVals.empty())
-    return emitOpError("init_vals must be empty when there are no combiners");
 
-  // When init_vals is provided it must match the scalar results in count and
-  // type.
-  if (!initVals.empty()) {
-    if (initVals.size() != scalarResultTypes.size())
-      return emitOpError("init_vals has ")
-             << initVals.size() << " value(s) but there are "
-             << scalarResultTypes.size() << " scalar result(s)";
-    for (auto [i, initVal] : llvm::enumerate(initVals)) {
-      Type resultTy = scalarResultTypes[i];
-      if (initVal.getType() != resultTy)
-        return emitOpError("init_vals[")
-               << i << "] has type " << initVal.getType()
-               << " but scalar result " << i << " has type " << resultTy;
-    }
+  // reductionDims entries must be valid indices into blockShape.
+  for (auto [i, dim] : llvm::enumerate(reductionDims)) {
+    if (dim < 0 || (unsigned)dim >= blockShape.size())
+      return emitOpError("reductionDims[")
+             << i << "] = " << dim << " is out of range for blockShape of size "
+             << blockShape.size();
   }
 
-  // Combiners region must have one block per scalar result.
-  if (!combiners.getBlocks().empty()) {
-    // if we have combiners we are currently limited to only one block in the
-    // body region
-    if (body.getBlocks().size() != 1)
-      return emitOpError("currently only supports one block in "
-                         "the body region with populated combiners, got ")
-             << body.getBlocks().size();
+  // reductionDims must not contain duplicates.
+  SmallVector<int32_t> sortedDims(reductionDims.begin(), reductionDims.end());
+  llvm::sort(sortedDims);
+  if (llvm::adjacent_find(sortedDims) != sortedDims.end())
+    return emitOpError("reductionDims must not contain duplicate entries");
+
+  // init_vals count must match reductionDims count.
+  if (initVals.size() != reductionDims.size())
+    return emitOpError("init_vals has ")
+           << initVals.size() << " value(s) but reductionDims has "
+           << reductionDims.size() << " entry(ies)";
+
+  // Body block must have numIVs + numIns + numIterArgs arguments.
+  unsigned numIns = getIns().size();
+  unsigned numIterArgs = reductionDims.size();
+  unsigned expectedArgs = numInductionVars + numIns + numIterArgs;
+  if (bodyBlock.getNumArguments() != expectedArgs)
+    return emitOpError("body block has ")
+           << bodyBlock.getNumArguments() << " argument(s) but expects "
+           << expectedArgs << " (numIVs=" << numInductionVars
+           << " + numIns=" << numIns << " + numIterArgs=" << numIterArgs << ")";
+
+  // Each iter arg block arg type must match the corresponding init_vals type.
+  for (auto [i, initVal] : llvm::enumerate(initVals)) {
+    BlockArgument iterArg =
+        bodyBlock.getArgument(numInductionVars + numIns + i);
+    if (iterArg.getType() != initVal.getType())
+      return emitOpError("body iter arg ")
+             << i << " has type " << iterArg.getType() << " but init_vals[" << i
+             << "] has type " << initVal.getType();
   }
-  unsigned numScalarResults = std::accumulate(
-      getResults().begin(), getResults().end(), 0, [](int sum, Value v) {
-        if (!isa<RankedTensorType>(v.getType()))
-          return sum + 1;
-        return sum;
-      });
-  if (combiners.getBlocks().size() != numScalarResults) {
-    return emitOpError("expects combiners region to have ")
-           << numScalarResults << " block(s), got "
-           << combiners.getBlocks().size();
-  }
-  for (auto [i, block] : llvm::enumerate(combiners.getBlocks())) {
-    Type resultTy = getResultTypes()[i];
-    if (block.getNumArguments() != 2 ||
-        block.getArgument(0).getType() != resultTy ||
-        block.getArgument(1).getType() != resultTy) {
-      return emitOpError("combiner block ")
-             << i << " expects two arguments of type " << resultTy;
-    }
+
+  // ttc.yield leading values must match iter arg types.
+  auto yieldOp = dyn_cast<cpu::YieldOp>(bodyBlock.getTerminator());
+  if (!yieldOp)
+    return emitOpError("body block must be terminated by ttc.yield");
+  if (yieldOp.getValues().size() < numIterArgs)
+    return emitOpError("ttc.yield must return at least ")
+           << numIterArgs << " value(s) for iter args, got "
+           << yieldOp.getValues().size();
+  for (unsigned i = 0; i < numIterArgs; ++i) {
+    Type yieldTy = yieldOp.getValues()[i].getType();
+    Type iterArgTy =
+        bodyBlock.getArgument(numInductionVars + numIns + i).getType();
+    if (yieldTy != iterArgTy)
+      return emitOpError("ttc.yield value ")
+             << i << " has type " << yieldTy << " but iter arg " << i
+             << " expects type " << iterArgTy;
   }
 
   return success();

--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -76,8 +76,35 @@ LogicalResult GenericOp::verify() {
       return emitOpError("body induction variable ") << i << " must be i32";
   }
 
-  // Combiners region must have one block per scalar result.
+  // Collect scalar result types for init_vals and combiner validation.
+  SmallVector<Type> scalarResultTypes;
+  for (Value result : getResults())
+    if (!isa<RankedTensorType>(result.getType()))
+      scalarResultTypes.push_back(result.getType());
+
+  // init_vals must be empty when there are no combiners.
+  auto initVals = getInitVals();
   Region &combiners = getCombiners();
+  if (combiners.getBlocks().empty() && !initVals.empty())
+    return emitOpError("init_vals must be empty when there are no combiners");
+
+  // When init_vals is provided it must match the scalar results in count and
+  // type.
+  if (!initVals.empty()) {
+    if (initVals.size() != scalarResultTypes.size())
+      return emitOpError("init_vals has ")
+             << initVals.size() << " value(s) but there are "
+             << scalarResultTypes.size() << " scalar result(s)";
+    for (auto [i, initVal] : llvm::enumerate(initVals)) {
+      Type resultTy = scalarResultTypes[i];
+      if (initVal.getType() != resultTy)
+        return emitOpError("init_vals[")
+               << i << "] has type " << initVal.getType()
+               << " but scalar result " << i << " has type " << resultTy;
+    }
+  }
+
+  // Combiners region must have one block per scalar result.
   if (!combiners.getBlocks().empty()) {
     // if we have combiners we are currently limited to only one block in the
     // body region

--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -99,10 +99,10 @@ LogicalResult GenericOp::verify() {
            << initVals.size() << " value(s) but reductionDims has "
            << reductionDims.size() << " entry(ies)";
 
-  // Body block must have numIVs + numIns + numIterArgs arguments.
+  // Body block must have numIVs + numIterArgs + numIns arguments.
   unsigned numIns = getIns().size();
   unsigned numIterArgs = reductionDims.size();
-  unsigned expectedArgs = numInductionVars + numIns + numIterArgs;
+  unsigned expectedArgs = numInductionVars + numIterArgs + numIns;
   if (bodyBlock.getNumArguments() != expectedArgs)
     return emitOpError("body block has ")
            << bodyBlock.getNumArguments() << " argument(s) but expects "
@@ -111,8 +111,7 @@ LogicalResult GenericOp::verify() {
 
   // Each iter arg block arg type must match the corresponding init_vals type.
   for (auto [i, initVal] : llvm::enumerate(initVals)) {
-    BlockArgument iterArg =
-        bodyBlock.getArgument(numInductionVars + numIns + i);
+    BlockArgument iterArg = bodyBlock.getArgument(numInductionVars + i);
     if (iterArg.getType() != initVal.getType())
       return emitOpError("body iter arg ")
              << i << " has type " << iterArg.getType() << " but init_vals[" << i
@@ -129,8 +128,7 @@ LogicalResult GenericOp::verify() {
            << yieldOp.getValues().size();
   for (unsigned i = 0; i < numIterArgs; ++i) {
     Type yieldTy = yieldOp.getValues()[i].getType();
-    Type iterArgTy =
-        bodyBlock.getArgument(numInductionVars + numIns + i).getType();
+    Type iterArgTy = bodyBlock.getArgument(numInductionVars + i).getType();
     if (yieldTy != iterArgTy)
       return emitOpError("ttc.yield value ")
              << i << " has type " << yieldTy << " but iter arg " << i

--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -119,9 +119,19 @@ LogicalResult GenericOp::verify() {
   }
 
   // ttc.yield leading values must match iter arg types.
-  auto yieldOp = dyn_cast<cpu::YieldOp>(bodyBlock.getTerminator());
+  // The body may have multiple blocks after SCF-to-CF lowering (e.g. a K-loop
+  // inside the body). Scan all blocks to find the unique ttc.yield.
+  cpu::YieldOp yieldOp;
+  for (Block &block : body) {
+    auto y = dyn_cast<cpu::YieldOp>(block.getTerminator());
+    if (!y)
+      continue;
+    if (yieldOp)
+      return emitOpError("body region must have exactly one ttc.yield");
+    yieldOp = y;
+  }
   if (!yieldOp)
-    return emitOpError("body block must be terminated by ttc.yield");
+    return emitOpError("body region must contain a ttc.yield terminator");
   if (yieldOp.getValues().size() < numIterArgs)
     return emitOpError("ttc.yield must return at least ")
            << numIterArgs << " value(s) for iter args, got "

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -165,15 +165,15 @@ static Block *initGenericBody(OpBuilder &rewriter, cpu::GenericOp generic,
     body->addArgument(rewriter.getI32Type(),
                       generic.getLoc()); // tile offset per vector shape dim
 
+  // Iter args before ins args — one block arg per reduction dim init val.
+  for (Value initVal : generic.getInitVals())
+    body->addArgument(initVal.getType(), initVal.getLoc());
+
   for (auto pair : ins) {
     auto [v, inputTileShape] = pair;
     Type argTy = updateTensorType(v.getType(), inputTileShape);
     mapping.map(v, body->addArgument(argTy, v.getLoc()));
   }
-
-  // Iter args trail ins args — one block arg per reduction dim init val.
-  for (Value initVal : generic.getInitVals())
-    body->addArgument(initVal.getType(), initVal.getLoc());
 
   rewriter.setInsertionPointToStart(body);
   return body;
@@ -296,9 +296,10 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
                                               neutralVal.value());
     SmallVector<Value> initVals = {newAccum.getResult()};
 
-    auto generic = cpu::GenericOp::create(rewriter, loc, resultTypes, insValues,
-                                          initVals, blockShapeValues, tileShape,
-                                          /*reductionDims=*/{0});
+    auto generic =
+        cpu::GenericOp::create(rewriter, loc, resultTypes, initVals, insValues,
+                               blockShapeValues, tileShape,
+                               /*reductionDims=*/{0});
 
     IRMapping bodyMapping;
     initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
@@ -503,7 +504,8 @@ struct FuseElementwiseIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
   matchAndRewrite(cpu::GenericOp genericOp,
                   mlir::PatternRewriter &rewriter) const override {
     Block *body = &genericOp.getBody().front();
-    unsigned numIV = genericOp.getNumInductionVars();
+    // TODO: rename variable?
+    unsigned numIV = genericOp.getInsArgOffset();
 
     for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
       Operation *op = insVal.getDefiningOp();
@@ -575,7 +577,7 @@ struct FuseMakeRangeIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
   matchAndRewrite(cpu::GenericOp genericOp,
                   mlir::PatternRewriter &rewriter) const override {
     Block *body = &genericOp.getBody().front();
-    unsigned numIV = genericOp.getNumInductionVars();
+    unsigned numIV = genericOp.getInsArgOffset();
 
     for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
       Operation *op = insVal.getDefiningOp();
@@ -671,7 +673,7 @@ struct FuseConstantIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
   matchAndRewrite(cpu::GenericOp genericOp,
                   mlir::PatternRewriter &rewriter) const override {
     Block *body = &genericOp.getBody().front();
-    unsigned numIV = genericOp.getNumInductionVars();
+    unsigned numIV = genericOp.getInsArgOffset();
 
     for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
       Operation *op = insVal.getDefiningOp();
@@ -727,7 +729,7 @@ struct FuseBroadcastIntoGeneric
   matchAndRewrite(cpu::GenericOp genericOp,
                   mlir::PatternRewriter &rewriter) const override {
     Block *body = &genericOp.getBody().front();
-    unsigned numIV = genericOp.getNumInductionVars();
+    unsigned numIV = genericOp.getInsArgOffset();
 
     for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
       Operation *op = insVal.getDefiningOp();
@@ -791,7 +793,7 @@ struct FuseExpandDimsIntoGeneric
   matchAndRewrite(cpu::GenericOp genericOp,
                   mlir::PatternRewriter &rewriter) const override {
     Block *body = &genericOp.getBody().front();
-    unsigned numIV = genericOp.getNumInductionVars();
+    unsigned numIV = genericOp.getInsArgOffset();
 
     for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
       Operation *op = insVal.getDefiningOp();
@@ -856,7 +858,7 @@ struct FuseConvertLayoutOpIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
   matchAndRewrite(cpu::GenericOp genericOp,
                   mlir::PatternRewriter &rewriter) const override {
     Block *body = &genericOp.getBody().front();
-    unsigned numIV = genericOp.getNumInductionVars();
+    unsigned numIV = genericOp.getInsArgOffset();
 
     for (auto [i, insVal] : llvm::enumerate(genericOp.getIns())) {
       Operation *op = insVal.getDefiningOp();
@@ -1011,6 +1013,7 @@ struct FuseParentForOpIntoGeneric : mlir::OpRewritePattern<scf::ForOp> {
 
     cpu::GenericOp genericOp = *targetGenericOp;
 
+    // TODO: handle carefully
     unsigned numIV = genericOp.getNumInductionVars();
     Block &genericBody = genericOp.getBody().front();
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -270,6 +270,13 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
           return user != reduceOp.getOperation(); // or just != reduceOp?
         });
 
+    Operation *combiner = reduceOp.getSingleCombiner();
+    if (!combiner)
+      return failure();
+    auto neutralVal = getNeutralElement(combiner);
+    if (!neutralVal)
+      return failure();
+
     auto [blockShape, tileShape] = getBlockAndTileShapes(tensorTy, encoding);
 
     SmallVector<TiledInput> ins = {TiledInput{srcs[0], tileShape}};
@@ -285,51 +292,41 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
     SmallVector<Value> blockShapeValues =
         buildBlockShapeValues(loc, blockShape, rewriter);
 
-    // TODO: add init vals, reduction dims, and drop the combiners stuff
+    auto newAccum = arith::ConstantOp::create(rewriter, reduceOp.getLoc(),
+                                              neutralVal.value());
+    SmallVector<Value> initVals = {newAccum.getResult()};
+
     auto generic = cpu::GenericOp::create(rewriter, loc, resultTypes, insValues,
-                                          blockShapeValues, tileShape);
+                                          initVals, blockShapeValues, tileShape,
+                                          /*reductionDims=*/{0});
 
     IRMapping bodyMapping;
     initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
 
     // Clone the reduce — it now operates on the tile-sized tensor.
     auto *newReduce = rewriter.clone(*reduceOp, bodyMapping);
+    Value acc = newReduce->getResult(0);
 
-    SmallVector<Value> partials(newReduce->getResults().begin(),
-                                newReduce->getResults().end());
-    if (srcUsedElsewhere)
-      partials.push_back(bodyMapping.lookup(srcs[0]));
-    cpu::YieldOp::create(rewriter, loc, partials);
+    // manually combine with the iter args source
+    auto partial = generic.getIterArg(0);
 
-    // Each block takes (acc, partial) and applies the same combining op as the
-    // tt.reduce combiner, replacing tt.reduce.return with ttc.yield.
-    Region &combiners = generic.getCombiners();
     Region &reduceCombiner = reduceOp.getCombineOp();
     Block &srcBlock = reduceCombiner.front();
 
-    // Only scalar (reduction) results need combiner blocks. The tensor result
-    // (if present) uses scatter semantics and has no combiner.
-    for (Type resultTy : reduceOp.getResultTypes()) {
-      Block *combBlock = rewriter.createBlock(&combiners);
-      Value acc = combBlock->addArgument(resultTy, loc);
-      Value partial = combBlock->addArgument(resultTy, loc);
+    IRMapping combMapping;
+    // The reduce combiner block has args [lhs..., rhs...] interleaved per
+    // src. With a single src the layout is simply [lhs, rhs].
+    combMapping.map(srcBlock.getArgument(0), acc);
+    combMapping.map(srcBlock.getArgument(1), partial);
+    auto newCombiner = rewriter.clone(*combiner, combMapping);
 
-      IRMapping combMapping;
-      // The reduce combiner block has args [lhs..., rhs...] interleaved per
-      // src. With a single src the layout is simply [lhs, rhs].
-      combMapping.map(srcBlock.getArgument(0), acc);
-      combMapping.map(srcBlock.getArgument(1), partial);
+    SmallVector<Value> partials(newCombiner->getResults().begin(),
+                                newCombiner->getResults().end());
 
-      rewriter.setInsertionPointToStart(combBlock);
-      for (Operation &op : srcBlock.without_terminator())
-        rewriter.clone(op, combMapping);
-
-      // Replace tt.reduce.return with ttc.yield.
-      SmallVector<Value> yieldVals;
-      for (Value rv : srcBlock.getTerminator()->getOperands())
-        yieldVals.push_back(combMapping.lookupOrDefault(rv));
-      cpu::YieldOp::create(rewriter, loc, yieldVals);
-    }
+    // TODO: we should really handle this during fusion...
+    if (srcUsedElsewhere)
+      partials.push_back(bodyMapping.lookup(srcs[0]));
+    cpu::YieldOp::create(rewriter, loc, partials);
 
     // Replace uses of srcs[0] outside the generic with the materialized tensor
     // result. Must go through the rewriter and exclude the generic's own

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -1,8 +1,11 @@
 #include "cpu/include/Dialect/TritonCPU/Transforms/Passes.h"
 
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/APFloat.h"
 #include "llvm/Support/Debug.h"
 
 #include "triton/Analysis/Utility.h"
@@ -126,6 +129,24 @@ getBlockedRegisterConversionTileShape(RankedTensorType srcTy,
   return tileShape;
 }
 
+// Get the neutral (identity) element for a reduction op. Handles
+// MaxNumFOp/MinNumFOp which are missing from mlir::arith::getNeutralElement,
+// and delegates everything else to it.
+// note: copied from optimizethreadlocality.cpp
+static std::optional<TypedAttr> getNeutralElement(Operation *op) {
+  if (isa<arith::MaxNumFOp>(op)) {
+    Type ty = op->getResult(0).getType();
+    const llvm::fltSemantics &sem = cast<FloatType>(ty).getFloatSemantics();
+    return FloatAttr::get(ty, APFloat::getInf(sem, /*Negative=*/true));
+  }
+  if (isa<arith::MinNumFOp>(op)) {
+    Type ty = op->getResult(0).getType();
+    const llvm::fltSemantics &sem = cast<FloatType>(ty).getFloatSemantics();
+    return FloatAttr::get(ty, APFloat::getInf(sem, /*Negative=*/false));
+  }
+  return mlir::arith::getNeutralElement(op);
+}
+
 struct TiledInput {
   Value value;
   SmallVector<int32_t> shape;
@@ -134,7 +155,8 @@ struct TiledInput {
 // Create the body block of a GenericOp, adding one block arg per ins value
 // with tensor types replaced to the vector (chunk) shape. Populates `mapping`
 // with ins value → block arg entries and sets the insertion point to the start
-// of the block. Returns the new block.
+// of the block. Iter args (one per reduction dim init val) are appended after
+// ins args. Returns the new block.
 static Block *initGenericBody(OpBuilder &rewriter, cpu::GenericOp generic,
                               ArrayRef<TiledInput> ins,
                               ArrayRef<int32_t> tileShape, IRMapping &mapping) {
@@ -148,6 +170,11 @@ static Block *initGenericBody(OpBuilder &rewriter, cpu::GenericOp generic,
     Type argTy = updateTensorType(v.getType(), inputTileShape);
     mapping.map(v, body->addArgument(argTy, v.getLoc()));
   }
+
+  // Iter args trail ins args — one block arg per reduction dim init val.
+  for (Value initVal : generic.getInitVals())
+    body->addArgument(initVal.getType(), initVal.getLoc());
+
   rewriter.setInsertionPointToStart(body);
   return body;
 }
@@ -257,6 +284,8 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
         llvm::map_to_vector(ins, [](const TiledInput &ti) { return ti.value; });
     SmallVector<Value> blockShapeValues =
         buildBlockShapeValues(loc, blockShape, rewriter);
+
+    // TODO: add init vals, reduction dims, and drop the combiners stuff
     auto generic = cpu::GenericOp::create(rewriter, loc, resultTypes, insValues,
                                           blockShapeValues, tileShape);
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -1013,7 +1013,9 @@ struct FuseParentForOpIntoGeneric : mlir::OpRewritePattern<scf::ForOp> {
 
     cpu::GenericOp genericOp = *targetGenericOp;
 
-    // TODO: handle carefully
+    // TODO: this assumes no iter args for dot cases where we want to fuse the
+    // for loop. when we fuse the for loop and expand the generic to handle the
+    // K dimension, this code will be wrong.
     unsigned numIV = genericOp.getNumInductionVars();
     Block &genericBody = genericOp.getBody().front();
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -155,8 +155,8 @@ struct TiledInput {
 // Create the body block of a GenericOp, adding one block arg per ins value
 // with tensor types replaced to the vector (chunk) shape. Populates `mapping`
 // with ins value → block arg entries and sets the insertion point to the start
-// of the block. Iter args (one per reduction dim init val) are appended after
-// ins args. Returns the new block.
+// of the block. Init values for iter args come first, then ins args. Returns
+// the new block.
 static Block *initGenericBody(OpBuilder &rewriter, cpu::GenericOp generic,
                               ArrayRef<TiledInput> ins,
                               ArrayRef<int32_t> tileShape, IRMapping &mapping) {
@@ -306,10 +306,10 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
 
     // Clone the reduce — it now operates on the tile-sized tensor.
     auto *newReduce = rewriter.clone(*reduceOp, bodyMapping);
-    Value acc = newReduce->getResult(0);
+    Value partial = newReduce->getResult(0);
 
     // manually combine with the iter args source
-    auto partial = generic.getIterArg(0);
+    auto acc = generic.getIterArg(0);
 
     Region &reduceCombiner = reduceOp.getCombineOp();
     Block &srcBlock = reduceCombiner.front();

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -112,78 +112,48 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     return chunkedArgs;
   }
 
-  SmallVector<Value> cloneTileBody(cpu::GenericOp op,
-                                   ConversionPatternRewriter &rewriter,
-                                   ArrayRef<Value> chunkedArgs,
-                                   ArrayRef<Value> tileOffsets,
-                                   Value &result) const {
+  // Returns {newIterArgVals, tensorTiles} from the tile's ttc.yield.
+  // iterArgVals provides the current accumulator values for iter args.
+  std::pair<SmallVector<Value>, SmallVector<Value>>
+  cloneTileBody(cpu::GenericOp op, ConversionPatternRewriter &rewriter,
+                ArrayRef<Value> iterArgVals, ArrayRef<Value> chunkedArgs,
+                ArrayRef<Value> tileOffsets) const {
     assert(op.getBody().getBlocks().size() == 1 &&
            "expected generic op body to have one block");
     Block *body = &op.getBody().front();
-    const bool hasReductions = false; //! op.getCombiners().empty();
 
-    // clone the body of the generic op for this chunk only
     IRMapping mapping;
+    // IVs
     for (auto [blockArg, offset] : llvm::zip(
              body->getArguments().take_front(tileOffsets.size()), tileOffsets))
       mapping.map(blockArg, offset);
+    // iter args: positions numIVs..numIVs+numIterArgs-1
+    for (auto [i, iterArgVal] : llvm::enumerate(iterArgVals))
+      mapping.map(body->getArgument(op.getNumInductionVars() + i), iterArgVal);
+    // ins args: positions insArgOffset..
     for (auto [bodyArg, chunkedArg] :
          llvm::zip(body->getArguments().drop_front(op.getInsArgOffset()),
                    chunkedArgs))
       mapping.map(bodyArg, chunkedArg);
 
-    SmallVector<Value> tensorTiles;
+    unsigned numIterArgs = op.getNumIterArgs();
+    SmallVector<Value> newIterArgVals, tensorTiles;
 
     for (Operation &bOp : *body) {
       if (auto yieldOp = dyn_cast<cpu::YieldOp>(bOp)) {
         if (yieldOp.getValues().empty())
           continue;
-
-        auto yieldOpValues = llvm::to_vector(llvm::map_range(
+        auto yieldVals = llvm::to_vector(llvm::map_range(
             yieldOp.getValues(), [&](Value v) { return mapping.lookup(v); }));
-
-        if (hasReductions) {
-          if (!result) {
-            result = yieldOpValues[0];
-          } else {
-            // combine with the previous reduction result using the same
-            // combiner region
-            auto *combinerBlock = &op.getCombiners().front();
-            IRMapping combMapping;
-            combMapping.map(combinerBlock->getArgument(0), result);
-            combMapping.map(combinerBlock->getArgument(1), yieldOpValues[0]);
-
-            auto terminator =
-                cast<cpu::YieldOp>(combinerBlock->getTerminator());
-            auto yieldVals = terminator.getValues();
-            assert(
-                yieldVals.size() == 1 &&
-                "expected exactly one value yielded from the combiner block");
-
-            Operation *combinerOp = yieldVals.front().getDefiningOp();
-            assert(combinerOp && "expected yielded value to be defined by an "
-                                 "op in the combiner block");
-            auto newCombiner = rewriter.clone(*combinerOp, combMapping);
-            result = newCombiner->getResult(0);
-          }
-
-          // materialzied tensor values are currently added to yield op after
-          // scalars
-          // TODO: remove, but this entire code block is false anyways
-          unsigned numCombinerBlocks = op.getCombiners().getBlocks().size();
-          for (unsigned k = numCombinerBlocks; k < yieldOpValues.size(); ++k)
-            tensorTiles.push_back(yieldOpValues[k]);
-        } else {
-          for (unsigned k = 0; k < yieldOpValues.size(); ++k)
-            tensorTiles.push_back(yieldOpValues[k]);
-        }
-
+        newIterArgVals.assign(yieldVals.begin(),
+                              yieldVals.begin() + numIterArgs);
+        tensorTiles.assign(yieldVals.begin() + numIterArgs, yieldVals.end());
       } else {
         rewriter.clone(bOp, mapping);
       }
     }
 
-    return tensorTiles;
+    return {newIterArgVals, tensorTiles};
   }
 
   void scatterTiles(ConversionPatternRewriter &rewriter, Location loc,
@@ -272,10 +242,12 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
   // statically unroll all tiles. Required when any tensor input uses
   // llvm.extractvalue (which requires compile-time indices), or when there is
   // only one tile and loop overhead is unnecessary.
+  // iterArgVals is updated in-place to the final accumulated values.
   void emitUnrolled(cpu::GenericOp op, OpAdaptor adaptor,
                     ConversionPatternRewriter &rewriter, unsigned numChunks,
                     unsigned vectorSize, ArrayRef<int32_t> blockShape,
-                    ArrayRef<int32_t> tileShape, Value &result,
+                    ArrayRef<int32_t> tileShape,
+                    SmallVectorImpl<Value> &iterArgVals,
                     ArrayRef<Value> tensorAccPtrs,
                     ArrayRef<Type> tensorElemTys) const {
     Location loc = op.getLoc();
@@ -304,13 +276,14 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
       Value flatOffset = b.i32_val(i * vectorSize);
       LDBG("flatOffset = " << (i * vectorSize));
-      auto tiles =
-          cloneTileBody(op, rewriter, chunkedArgs, perDimOffsets, result);
+      auto [newIterArgVals, tiles] =
+          cloneTileBody(op, rewriter, iterArgVals, chunkedArgs, perDimOffsets);
+      iterArgVals.assign(newIterArgVals.begin(), newIterArgVals.end());
       scatterTiles(rewriter, loc, tiles, flatOffset, vectorSize, tensorAccPtrs,
                    tensorElemTys);
     }
   }
-
+#if 0
   // emit a loop over tiles carrying a reduction accumulator.
   // The first tile is peeled to establish the initial accumulator value, then
   // tiles 1..numChunks-1 are processed in a loop with (i, acc) as loop-carried
@@ -374,55 +347,84 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     rewriter.setInsertionPointToStart(afterBlock);
     result = afterResult;
   }
-
-  void emitSingleLoop(
-      ConversionPatternRewriter &rewriter, Location loc, int32_t numChunks,
-      int32_t tileSize,
-      llvm::function_ref<void(Value /*loopI*/, Value /*dimTileOffset*/,
-                              Block * /*afterBlock*/)>
-          bodyFn) const {
+#endif
+  // Emits a loop over numChunks tiles, carrying initCarried values as
+  // loop-carried state alongside the loop counter. bodyFn receives the current
+  // carried values and returns the updated carried values for the back edge.
+  // Returns the final carried values available after the loop.
+  SmallVector<Value>
+  emitSingleLoop(ConversionPatternRewriter &rewriter, Location loc,
+                 int32_t numChunks, int32_t tileSize,
+                 ArrayRef<Value> initCarried,
+                 llvm::function_ref<SmallVector<Value>(
+                     Value /*loopI*/, Value /*dimTileOffset*/,
+                     ArrayRef<Value> /*carried*/, Block * /*afterBlock*/)>
+                     bodyFn) const {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
     Block *currentBlock = rewriter.getInsertionBlock();
     Block *afterBlock =
         rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
 
-    // loop-carried value: (i: i32) only
-    Block *loopHeader = rewriter.createBlock(afterBlock, {i32_ty}, {loc});
+    // afterBlock receives the final carried values
+    SmallVector<Type> carriedTys;
+    for (Value v : initCarried)
+      carriedTys.push_back(v.getType());
+    for (Type ty : carriedTys)
+      afterBlock->addArgument(ty, loc);
+
+    // loop header: (i: i32, carried...)
+    SmallVector<Type> headerTys = {i32_ty};
+    headerTys.append(carriedTys);
+    SmallVector<Location> headerLocs(headerTys.size(), loc);
+    Block *loopHeader = rewriter.createBlock(afterBlock, headerTys, headerLocs);
     Block *loopBody = rewriter.createBlock(afterBlock);
 
-    // currentBlock -> loopHeader(0)
+    // currentBlock -> loopHeader(0, initCarried...)
     rewriter.setInsertionPointToEnd(currentBlock);
-    LLVM::BrOp::create(rewriter, loc, ValueRange{b.i32_val(0)}, loopHeader);
+    SmallVector<Value> initArgs = {b.i32_val(0)};
+    initArgs.append(initCarried.begin(), initCarried.end());
+    LLVM::BrOp::create(rewriter, loc, initArgs, loopHeader);
 
-    // loopHeader: check i < numChunks, branch to body or exit
+    // loopHeader: check i < numChunks, branch to body or exit with carried
     rewriter.setInsertionPointToEnd(loopHeader);
     Value loopI = loopHeader->getArgument(0);
+    SmallVector<Value> currentCarried;
+    for (unsigned i = 0; i < carriedTys.size(); ++i)
+      currentCarried.push_back(loopHeader->getArgument(1 + i));
     Value cond = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::ult,
                                       loopI, b.i32_val(numChunks));
-    LLVM::CondBrOp::create(rewriter, loc, cond, loopBody, {}, afterBlock, {});
+    LLVM::CondBrOp::create(rewriter, loc, cond, loopBody, {}, afterBlock,
+                           currentCarried);
 
-    // loop body: emit tile, increment counter
+    // loop body: emit tile, increment counter, branch back with new carried
     rewriter.setInsertionPointToEnd(loopBody);
-
     Value tileOffset = b.mul(loopI, b.i32_val(tileSize));
-    bodyFn(loopI, tileOffset, afterBlock);
+    SmallVector<Value> newCarried =
+        bodyFn(loopI, tileOffset, currentCarried, afterBlock);
 
     Value nextI = LLVM::AddOp::create(rewriter, loc, loopI, b.i32_val(1));
-    LLVM::BrOp::create(rewriter, loc, ValueRange{nextI}, loopHeader);
+    SmallVector<Value> nextArgs = {nextI};
+    nextArgs.append(newCarried.begin(), newCarried.end());
+    LLVM::BrOp::create(rewriter, loc, nextArgs, loopHeader);
 
     rewriter.setInsertionPointToStart(afterBlock);
+
+    SmallVector<Value> finalCarried;
+    for (unsigned i = 0; i < carriedTys.size(); ++i)
+      finalCarried.push_back(afterBlock->getArgument(i));
+    return finalCarried;
   }
 
-  // Path 3: emit a loop over tiles with no reduction accumulator.
-  // Loops from i=0 to numChunks-1 carrying only the loop counter. No first-
-  // iteration peeling is needed since there is no accumulator to bootstrap.
+  // Emits nested loops over tiles, threading iter arg values as loop-carried
+  // state. iterArgVals is updated in-place to the final accumulated values.
   void emitNestedLoops(cpu::GenericOp op, OpAdaptor adaptor,
                        ConversionPatternRewriter &rewriter, unsigned dim,
                        SmallVectorImpl<Value> &accOffsets, Value flatElemOffset,
                        ArrayRef<int32_t> blockShape,
                        ArrayRef<int32_t> tileShape, unsigned vectorSize,
-                       Value &result, ArrayRef<Value> tensorAccPtrs,
+                       SmallVectorImpl<Value> &iterArgVals,
+                       ArrayRef<Value> tensorAccPtrs,
                        ArrayRef<Type> tensorElemTys,
                        Block *innerAfterBlock = nullptr) const {
     Location loc = op.getLoc();
@@ -431,15 +433,14 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     unsigned rank = blockShape.size();
 
     if (dim == rank) {
-      // innermost loop, inline generic op body
+      // innermost: inline the body region
       assert(innerAfterBlock &&
              "expected inner after block for innermost loop");
 
       Region &bodyRegion = op.getBody();
       Block *bodyEntry = &bodyRegion.front();
 
-      // must be built before inlining the region since it references block
-      // arguments
+      // build tile args before inlining (references block arguments)
       auto tileArgs = buildDynamicChunkedArgs(op, adaptor, rewriter,
                                               flatElemOffset, vectorSize);
 
@@ -452,10 +453,13 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       bodyEntry = rewriter.applySignatureConversion(bodyEntry, sigConv,
                                                     getTypeConverter());
 
+      // entryArgs: [IVs..., iterArgs..., insArgs...]
       SmallVector<Value> entryArgs(accOffsets.begin(), accOffsets.end());
+      entryArgs.append(iterArgVals.begin(), iterArgVals.end());
       entryArgs.append(tileArgs.begin(), tileArgs.end());
       LLVM::BrOp::create(rewriter, loc, entryArgs, bodyEntry);
 
+      unsigned numIterArgs = op.getNumIterArgs();
       for (Block &block : llvm::make_range(bodyEntry->getIterator(),
                                            innerAfterBlock->getIterator())) {
         auto yieldOp = dyn_cast<cpu::YieldOp>(block.getTerminator());
@@ -463,45 +467,51 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           continue;
 
         rewriter.setInsertionPoint(yieldOp);
-        // only scatter non-iter arg yields
-        SmallVector<Value> loopTiles(yieldOp.getValues().begin() +
-                                         op.getNumIterArgs(),
+        // extract new iter arg values from the leading yield operands
+        iterArgVals.clear();
+        for (unsigned i = 0; i < numIterArgs; ++i)
+          iterArgVals.push_back(yieldOp.getValues()[i]);
+
+        // scatter non-iter-arg tensor tiles
+        SmallVector<Value> loopTiles(yieldOp.getValues().begin() + numIterArgs,
                                      yieldOp.getValues().end());
         scatterTiles(rewriter, loc, loopTiles, flatElemOffset, vectorSize,
                      tensorAccPtrs, tensorElemTys);
 
-        // emit single loop handles branching to the next block, so just erase
-        // the yield and set the rewriter insertion point to the end of the last
-        // inlined block
         rewriter.eraseOp(yieldOp);
         rewriter.setInsertionPointToEnd(&block);
-        break; // only one ttc.yield per generic body
+        break;
       }
 
       return;
     }
 
-    // emit single loop, recurse to next level down
+    // emit single loop, recurse to next dimension
     int32_t numChunks = blockShape[dim] / tileShape[dim];
 
     int32_t innerStride = vectorSize;
-    for (unsigned d = dim + 1; d < rank; ++d) {
+    for (unsigned d = dim + 1; d < rank; ++d)
       innerStride *= blockShape[d] / tileShape[d];
-    }
 
-    emitSingleLoop(
-        rewriter, loc, numChunks, tileShape[dim],
-        [&](Value loopI, Value dimTileOffset, Block *afterBlock) {
+    auto finalCarried = emitSingleLoop(
+        rewriter, loc, numChunks, tileShape[dim], iterArgVals,
+        [&](Value loopI, Value dimTileOffset, ArrayRef<Value> currentCarried,
+            Block *afterBlock) -> SmallVector<Value> {
           accOffsets.push_back(dimTileOffset);
           Value newFlat =
               LLVM::AddOp::create(rewriter, loc, flatElemOffset,
                                   LLVM::MulOp::create(rewriter, loc, loopI,
                                                       b.i32_val(innerStride)));
+          SmallVector<Value> innerIterArgVals(currentCarried.begin(),
+                                              currentCarried.end());
           emitNestedLoops(op, adaptor, rewriter, dim + 1, accOffsets, newFlat,
-                          blockShape, tileShape, vectorSize, result,
+                          blockShape, tileShape, vectorSize, innerIterArgVals,
                           tensorAccPtrs, tensorElemTys, afterBlock);
           accOffsets.pop_back();
+          return innerIterArgVals;
         });
+
+    iterArgVals.assign(finalCarried.begin(), finalCarried.end());
   }
 
   LogicalResult
@@ -606,15 +616,22 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                        return true;
                      });
 
-    Value result;
+    // Iter arg values start from init_vals and are updated tile-by-tile.
+    SmallVector<Value> iterArgVals(adaptor.getInitVals().begin(),
+                                   adaptor.getInitVals().end());
+
     if (requiresTensorArgMaterialization || numChunks == 1) {
       emitUnrolled(op, adaptor, rewriter, numChunks, vectorSize, blockShape,
-                   tileShape, result, tensorAccPtrs, tensorElemTys);
+                   tileShape, iterArgVals, tensorAccPtrs, tensorElemTys);
     } else if (hasReductions) {
+#if 1
+      assert(false && "dead path");
+#else
       assert(blockShape.size() == 1 &&
              "only support rank-1 generic tiles in reductions path");
       emitLoopWithReductions(op, adaptor, rewriter, numChunks, vectorSize,
-                             result, tensorAccPtrs, tensorElemTys);
+                             iterArgVals.front(), tensorAccPtrs, tensorElemTys);
+#endif
     } else {
       const bool genericHasTensorOutputs =
           llvm::any_of(op->getResults(), [](Value result) {
@@ -631,33 +648,26 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       SmallVector<Value> accOffsets;
       auto b = TritonLLVMOpBuilder(loc, rewriter);
       emitNestedLoops(op, adaptor, rewriter, /*dim=*/0, accOffsets,
-                      b.i32_val(0), blockShape, tileShape, vectorSize, result,
-                      tensorAccPtrs, tensorElemTys);
+                      b.i32_val(0), blockShape, tileShape, vectorSize,
+                      iterArgVals, tensorAccPtrs, tensorElemTys);
     }
 
-#if 1
-    // TODO: this is broken
-    SmallVector<Value> replacements;
-    if (result)
-      replacements.push_back(result);
-    replacements.append(tensorAccPtrs);
-    if (!replacements.empty()) {
-#if 1
-      assert(replacements.size() == op.getNumIterArgs() &&
-             "expected one replacement value per iter-arg result");
-      for (auto [result, repl] :
-           llvm::zip(op.getResults().drop_back(op.getNumResults() -
-                                               op.getNumIterArgs()),
-                     replacements)) {
-        rewriter.replaceAllUsesWith(result, repl);
-      }
+    // Collect all replacement values atomically. Mixing replaceAllUsesWith +
+    // eraseOp in a ConversionPatternRewriter causes double-replacement
+    // assertions in the framework; a single replaceOp call avoids that.
+    unsigned numIterArgs = op.getNumIterArgs();
+    SmallVector<Value> allReplacements(iterArgVals.begin(), iterArgVals.end());
+    for (auto [res, accPtr] :
+         llvm::zip(op.getResults().drop_front(numIterArgs), tensorAccPtrs)) {
+      allReplacements.push_back(UnrealizedConversionCastOp::create(
+                                    rewriter, loc, res.getType(), accPtr)
+                                    .getResult(0));
     }
-#else
-      rewriter.replaceOp(op, replacements);
-    } else
-#endif
-#endif
-    rewriter.eraseOp(op);
+
+    if (allReplacements.empty())
+      rewriter.eraseOp(op);
+    else
+      rewriter.replaceOp(op, allReplacements);
     return success();
   }
 };

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -283,71 +283,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                    tensorElemTys);
     }
   }
-#if 0
-  // emit a loop over tiles carrying a reduction accumulator.
-  // The first tile is peeled to establish the initial accumulator value, then
-  // tiles 1..numChunks-1 are processed in a loop with (i, acc) as loop-carried
-  // values. The final accumulator is forwarded through the after block.
-  void emitLoopWithReductions(cpu::GenericOp op, OpAdaptor adaptor,
-                              ConversionPatternRewriter &rewriter,
-                              unsigned numChunks, unsigned vectorSize,
-                              Value &result, ArrayRef<Value> tensorAccPtrs,
-                              ArrayRef<Type> tensorElemTys) const {
-    Location loc = op.getLoc();
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    // peel tile 0 to establish the initial reduction accumulator
-    auto firstArgs =
-        buildStaticChunkedArgs(op, adaptor, rewriter, 0, vectorSize);
-    auto firstTiles =
-        cloneTileBody(op, rewriter, firstArgs, {b.i32_val(0)}, result);
-    scatterTiles(rewriter, loc, firstTiles, b.i32_val(0), vectorSize,
-                 tensorAccPtrs, tensorElemTys);
-
-    Block *currentBlock = rewriter.getInsertionBlock();
-    Block *afterBlock =
-        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
-    Value afterResult = afterBlock->addArgument(result.getType(), loc);
-
-    // loop-carried values: (i: i32, acc: result type)
-    Block *loopHeader = rewriter.createBlock(
-        afterBlock, {i32_ty, result.getType()}, {loc, loc});
-    Block *loopBody = rewriter.createBlock(afterBlock);
-
-    // currentBlock -> loopHeader(1, initialAcc)
-    rewriter.setInsertionPointToEnd(currentBlock);
-    LLVM::BrOp::create(rewriter, loc, ValueRange{b.i32_val(1), result},
-                       loopHeader);
-
-    // loopHeader: check i < numChunks, branch to body or exit
-    rewriter.setInsertionPointToEnd(loopHeader);
-    Value loopI = loopHeader->getArgument(0);
-    Value loopAcc = loopHeader->getArgument(1);
-    Value cond = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::ult,
-                                      loopI, b.i32_val(numChunks));
-    LLVM::CondBrOp::create(rewriter, loc, cond, loopBody, {}, afterBlock,
-                           ValueRange{loopAcc});
-
-    // loop body: emit tile, update accumulator, increment counter
-    rewriter.setInsertionPointToEnd(loopBody);
-    Value tileOffset =
-        LLVM::MulOp::create(rewriter, loc, loopI, b.i32_val(vectorSize));
-    auto tileArgs =
-        buildDynamicChunkedArgs(op, adaptor, rewriter, tileOffset, vectorSize);
-    Value tileResult = loopAcc;
-    auto loopTiles =
-        cloneTileBody(op, rewriter, tileArgs, {tileOffset}, tileResult);
-    scatterTiles(rewriter, loc, loopTiles, tileOffset, vectorSize,
-                 tensorAccPtrs, tensorElemTys);
-    Value nextI = LLVM::AddOp::create(rewriter, loc, loopI, b.i32_val(1));
-    LLVM::BrOp::create(rewriter, loc, ValueRange{nextI, tileResult},
-                       loopHeader);
-
-    // propagate final accumulator out of the loop
-    rewriter.setInsertionPointToStart(afterBlock);
-    result = afterResult;
-  }
-#endif
   // Emits a loop over numChunks tiles, carrying initCarried values as
   // loop-carried state alongside the loop counter. bodyFn receives the current
   // carried values and returns the updated carried values for the back edge.
@@ -544,9 +480,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       numChunks *= blockShape[d] / tileShape[d];
     }
 
-    // TODO: disable existing reductions pathway and use iter args consistently
-    const bool hasReductions = false; //! op.getCombiners().empty();
-
     LDBG("Lowering genericOp with vectorSize = "
          << vectorSize << ", numChunks = " << numChunks);
 
@@ -621,22 +554,12 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                      });
 
     // Iter arg values start from init_vals and are updated tile-by-tile.
-    // TODO: these probably have to be tiled?
     SmallVector<Value> iterArgVals(adaptor.getInitVals().begin(),
                                    adaptor.getInitVals().end());
 
     if (requiresTensorArgMaterialization || numChunks == 1) {
       emitUnrolled(op, adaptor, rewriter, numChunks, vectorSize, blockShape,
                    tileShape, iterArgVals, tensorAccPtrs, tensorElemTys);
-    } else if (hasReductions) {
-#if 1
-      assert(false && "dead path");
-#else
-      assert(blockShape.size() == 1 &&
-             "only support rank-1 generic tiles in reductions path");
-      emitLoopWithReductions(op, adaptor, rewriter, numChunks, vectorSize,
-                             iterArgVals.front(), tensorAccPtrs, tensorElemTys);
-#endif
     } else {
       const bool genericHasTensorOutputs =
           llvm::any_of(op->getResults(), [](Value result) {
@@ -662,16 +585,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     // assertions in the framework; a single replaceOp call avoids that.
     unsigned numIterArgs = op.getNumIterArgs();
     SmallVector<Value> allReplacements(iterArgVals.begin(), iterArgVals.end());
-#if 0
-    for (auto [res, accPtr] :
-         llvm::zip(op.getResults().drop_front(numIterArgs), tensorAccPtrs)) {
-      allReplacements.push_back(UnrealizedConversionCastOp::create(
-                                    rewriter, loc, res.getType(), accPtr)
-                                    .getResult(0));
-    }
-#else
     allReplacements.append(tensorAccPtrs);
-#endif
     if (allReplacements.empty())
       rewriter.eraseOp(op);
     else

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -25,7 +25,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
   Value getGenericOutputTensorAsPtr(cpu::GenericOp op, unsigned opIdx,
                                     Value llvmArg) const {
     // find the generic op producing this tensor
-    auto result = dyn_cast<OpResult>(op.getOperand(opIdx));
+    auto result = dyn_cast<OpResult>(op.getIns()[opIdx]);
     if (!result)
       return {};
     auto defGeneric = dyn_cast<cpu::GenericOp>(result.getOwner());
@@ -66,7 +66,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                origArg.getType() == llvmArg.getType() &&
                    "expected non-tensor arguments to be unchanged by type "
                    "conversion");
-        chunkedArgs.push_back(op.getOperand(opIdx));
+        chunkedArgs.push_back(op.getIns()[opIdx]);
       } else if (Value ptrArg =
                      getGenericOutputTensorAsPtr(op, opIdx, llvmArg)) {
         // Load this tile's elements from the alloca produced by the prior
@@ -221,10 +221,10 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         if (origArg.getType() != llvmArg.getType()) {
           tileArgs.push_back(
               UnrealizedConversionCastOp::create(
-                  rewriter, loc, llvmArg.getType(), op.getOperand(opIdx))
+                  rewriter, loc, llvmArg.getType(), op.getIns()[opIdx])
                   .getResult(0));
         } else {
-          tileArgs.push_back(op.getOperand(opIdx));
+          tileArgs.push_back(op.getIns()[opIdx]);
         }
       } else {
         assert(!isa<RankedTensorType>(origArg.getType()) &&
@@ -233,7 +233,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         assert(origArg.getType() == llvmArg.getType() &&
                "expected non-tensor arguments to be unchanged by type "
                "conversion");
-        tileArgs.push_back(op.getOperand(opIdx));
+        tileArgs.push_back(op.getIns()[opIdx]);
       }
     }
     return tileArgs;
@@ -455,7 +455,11 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
       // entryArgs: [IVs..., iterArgs..., insArgs...]
       SmallVector<Value> entryArgs(accOffsets.begin(), accOffsets.end());
+      for (auto arg : iterArgVals)
+        LDBG("iterArgVals: " << arg);
       entryArgs.append(iterArgVals.begin(), iterArgVals.end());
+      for (auto arg : tileArgs)
+        LDBG("tileArgs: " << arg);
       entryArgs.append(tileArgs.begin(), tileArgs.end());
       LLVM::BrOp::create(rewriter, loc, entryArgs, bodyEntry);
 

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -32,7 +32,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     if (!defGeneric)
       return {};
     // TODO: overly defensive?
-    if (result.getResultNumber() < defGeneric.getCombiners().getBlocks().size())
+    if (result.getResultNumber() < defGeneric.getNumIterArgs())
       return {};
 
     assert(isa<LLVM::LLVMStructType>(llvmArg.getType()) &&
@@ -56,9 +56,9 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     Block *body = &op.getBody().front();
     SmallVector<Value> chunkedArgs;
 
-    for (auto [opIdx, origArg, llvmArg] : llvm::enumerate(
-             body->getArguments().drop_front(op.getNumInductionVars()),
-             adaptor.getIns())) {
+    for (auto [opIdx, origArg, llvmArg] :
+         llvm::enumerate(body->getArguments().drop_front(op.getInsArgOffset()),
+                         adaptor.getIns())) {
       LDBG("Chunk operand " << opIdx << " = " << origArg << " --> " << llvmArg);
       if (!isa<RankedTensorType>(origArg.getType())) {
         // forward constants and scalars without chunking
@@ -120,7 +120,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     assert(op.getBody().getBlocks().size() == 1 &&
            "expected generic op body to have one block");
     Block *body = &op.getBody().front();
-    const bool hasReductions = !op.getCombiners().empty();
+    const bool hasReductions = false; //! op.getCombiners().empty();
 
     // clone the body of the generic op for this chunk only
     IRMapping mapping;
@@ -128,7 +128,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
              body->getArguments().take_front(tileOffsets.size()), tileOffsets))
       mapping.map(blockArg, offset);
     for (auto [bodyArg, chunkedArg] :
-         llvm::zip(body->getArguments().drop_front(op.getNumInductionVars()),
+         llvm::zip(body->getArguments().drop_front(op.getInsArgOffset()),
                    chunkedArgs))
       mapping.map(bodyArg, chunkedArg);
 
@@ -169,6 +169,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
           // materialzied tensor values are currently added to yield op after
           // scalars
+          // TODO: remove, but this entire code block is false anyways
           unsigned numCombinerBlocks = op.getCombiners().getBlocks().size();
           for (unsigned k = numCombinerBlocks; k < yieldOpValues.size(); ++k)
             tensorTiles.push_back(yieldOpValues[k]);
@@ -222,9 +223,9 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     SmallVector<Value> tileArgs;
 
-    for (auto [opIdx, origArg, llvmArg] : llvm::enumerate(
-             body->getArguments().drop_front(op.getNumInductionVars()),
-             adaptor.getIns())) {
+    for (auto [opIdx, origArg, llvmArg] :
+         llvm::enumerate(body->getArguments().drop_front(op.getInsArgOffset()),
+                         adaptor.getIns())) {
       if (Value ptrArg = getGenericOutputTensorAsPtr(op, opIdx, llvmArg)) {
         // Load this tile's elements from the alloca produced by the prior
         // generic and pack them into the tile struct.
@@ -462,7 +463,10 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           continue;
 
         rewriter.setInsertionPoint(yieldOp);
-        SmallVector<Value> loopTiles = llvm::to_vector(yieldOp.getValues());
+        // only scatter non-iter arg yields
+        SmallVector<Value> loopTiles(yieldOp.getValues().begin() +
+                                         op.getNumIterArgs(),
+                                     yieldOp.getValues().end());
         scatterTiles(rewriter, loc, loopTiles, flatElemOffset, vectorSize,
                      tensorAccPtrs, tensorElemTys);
 
@@ -526,12 +530,11 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       numChunks *= blockShape[d] / tileShape[d];
     }
 
-    const bool hasReductions = !op.getCombiners().empty();
-    const unsigned numCombinerBlocks = op.getCombiners().getBlocks().size();
+    // TODO: disable existing reductions pathway and use iter args consistently
+    const bool hasReductions = false; //! op.getCombiners().empty();
 
     LDBG("Lowering genericOp with vectorSize = "
-         << vectorSize << ", numChunks = " << numChunks << ", hasReductions = "
-         << hasReductions << ", numCombinerBlocks = " << numCombinerBlocks);
+         << vectorSize << ", numChunks = " << numChunks);
 
     // Tensor results are materialized as thread-local global arrays rather than
     // LLVM vectors. This avoids loop-carried <blockSize x elemTy> phi nodes
@@ -551,7 +554,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     auto module = op->getParentOfType<ModuleOp>();
     assert(module && "expected generic op to be inside a module");
     for (Type resultTy :
-         llvm::drop_begin(op.getResultTypes(), numCombinerBlocks)) {
+         llvm::drop_begin(op.getResultTypes(), op.getNumIterArgs())) {
       auto tensorTy = cast<RankedTensorType>(resultTy);
       int64_t blockSize = std::accumulate(blockShape.begin(), blockShape.end(),
                                           int64_t{1}, std::multiplies<>());
@@ -589,19 +592,19 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     // Tensor args passed as LLVM structs require static tile indices
     // (llvm.extractvalue only accepts attribute indices). Alloca-backed tensors
     // from a prior generic are GEP-indexed and support dynamic offsets.
-    const bool requiresTensorArgMaterialization = llvm::any_of(
-        llvm::enumerate(
-            llvm::zip(body->getArguments().drop_front(op.getNumInductionVars()),
-                      adaptor.getIns())),
-        [this, &op](auto pair) {
-          auto [opIdx, argPair] = pair;
-          auto [origArg, llvmArg] = argPair;
-          if (!isa<RankedTensorType>(origArg.getType()))
-            return false;
-          if (getGenericOutputTensorAsPtr(op, opIdx, llvmArg))
-            return false;
-          return true;
-        });
+    const bool requiresTensorArgMaterialization =
+        llvm::any_of(llvm::enumerate(llvm::zip(
+                         body->getArguments().drop_front(op.getInsArgOffset()),
+                         adaptor.getIns())),
+                     [this, &op](auto pair) {
+                       auto [opIdx, argPair] = pair;
+                       auto [origArg, llvmArg] = argPair;
+                       if (!isa<RankedTensorType>(origArg.getType()))
+                         return false;
+                       if (getGenericOutputTensorAsPtr(op, opIdx, llvmArg))
+                         return false;
+                       return true;
+                     });
 
     Value result;
     if (requiresTensorArgMaterialization || numChunks == 1) {
@@ -632,14 +635,29 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                       tensorAccPtrs, tensorElemTys);
     }
 
+#if 1
+    // TODO: this is broken
     SmallVector<Value> replacements;
     if (result)
       replacements.push_back(result);
     replacements.append(tensorAccPtrs);
-    if (!replacements.empty())
+    if (!replacements.empty()) {
+#if 1
+      assert(replacements.size() == op.getNumIterArgs() &&
+             "expected one replacement value per iter-arg result");
+      for (auto [result, repl] :
+           llvm::zip(op.getResults().drop_back(op.getNumResults() -
+                                               op.getNumIterArgs()),
+                     replacements)) {
+        rewriter.replaceAllUsesWith(result, repl);
+      }
+    }
+#else
       rewriter.replaceOp(op, replacements);
-    else
-      rewriter.eraseOp(op);
+    } else
+#endif
+#endif
+    rewriter.eraseOp(op);
     return success();
   }
 };

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -617,6 +617,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                      });
 
     // Iter arg values start from init_vals and are updated tile-by-tile.
+    // TODO: these probably have to be tiled?
     SmallVector<Value> iterArgVals(adaptor.getInitVals().begin(),
                                    adaptor.getInitVals().end());
 
@@ -657,13 +658,16 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     // assertions in the framework; a single replaceOp call avoids that.
     unsigned numIterArgs = op.getNumIterArgs();
     SmallVector<Value> allReplacements(iterArgVals.begin(), iterArgVals.end());
+#if 0
     for (auto [res, accPtr] :
          llvm::zip(op.getResults().drop_front(numIterArgs), tensorAccPtrs)) {
       allReplacements.push_back(UnrealizedConversionCastOp::create(
                                     rewriter, loc, res.getType(), accPtr)
                                     .getResult(0));
     }
-
+#else
+    allReplacements.append(tensorAccPtrs);
+#endif
     if (allReplacements.empty())
       rewriter.eraseOp(op);
     else

--- a/test/Analysis/axis-info-generic.mlir
+++ b/test/Analysis/axis-info-generic.mlir
@@ -17,11 +17,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
         %x_3 = tt.addptr %x, %offsets_1 : tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xi32, #blocked>
 
         // CHECK-COUNT-128: ttc.masked_load {{.*}} -> vector<4xf32>
-        ttc.generic (%x_3) blocks [%c512_i32 : i32] attributes {tileShape = array<i32: 4>} body {
+        ttc.generic (%x_3) blocks [%c512_i32 : i32] attributes {tileShape = array<i32: 4>, reductionDims = array<i32>} body {
             ^bb0(%offset:i32, %arg0: tensor<4x!tt.ptr<f32>, #blocked>):
                 %x_10 = tt.load %arg0 : tensor<4x!tt.ptr<f32>, #blocked>
                 ttc.yield
-        } combiners {}: (tensor<512x!tt.ptr<f32>, #blocked>) -> ()
+        }: (tensor<512x!tt.ptr<f32>, #blocked>) -> ()
         tt.return
     }
 }
@@ -32,7 +32,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
     tt.func public @load_scalar(%x_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
         %c1024_i32 = arith.constant 1024 : i32
-        ttc.generic (%x_ptr) blocks [%c1024_i32 : i32] attributes {tileShape = array<i32: 4>} body {
+        ttc.generic (%x_ptr) blocks [%c1024_i32 : i32] attributes {tileShape = array<i32: 4>, reductionDims = array<i32>} body {
             ^bb0(%tileOffset: i32, %ptr: !tt.ptr<f32>):
                 %offsets = ttc.make_dynamic_range %tileOffset : tensor<4xi32, #blocked>
                 %ptrs = tt.splat %ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>, #blocked>
@@ -46,7 +46,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
                 // CHECK: ttc.masked_load {{.*}} -> vector<4xf32>
                 %ret = tt.load %offset_ptrs : tensor<4x!tt.ptr<f32>, #blocked>
                 ttc.yield
-        } combiners {}: (!tt.ptr<f32>) -> ()
+        }: (!tt.ptr<f32>) -> ()
 
         tt.return
     }
@@ -70,7 +70,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %c4_i32 = arith.constant 4 : i32
     %c8_i32 = arith.constant 8 : i32
     ttc.generic (%data, %c_ptr, %stride_cm, %M, %N, %offs_am, %offs_bn) blocks
-        [%c4_i32, %c8_i32 : i32, i32] attributes {tileShape = array<i32: 1, 8>} body {
+        [%c4_i32, %c8_i32 : i32, i32] attributes {tileShape = array<i32: 1, 8>, reductionDims = array<i32>} body {
     ^bb0(%tile_m: i32, %tile_n: i32,
          %tile_data: tensor<1x8xf16, #blocked>,
          %ptr: !tt.ptr<f16>, %stride: i32, %m_bound: i32, %n_bound: i32,
@@ -116,7 +116,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
       tt.store %ptrs, %tile_data, %mask : tensor<1x8x!tt.ptr<f16>, #blocked>
       ttc.yield
-    } combiners {} : (tensor<4x8xf16, #blocked>, !tt.ptr<f16>, i32, i32, i32, i32, i32) -> ()
+    } : (tensor<4x8xf16, #blocked>, !tt.ptr<f16>, i32, i32, i32, i32, i32) -> ()
 
     tt.return
   }

--- a/test/Conversion/generic-op-loops.mlir
+++ b/test/Conversion/generic-op-loops.mlir
@@ -17,13 +17,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @scale_1d(%scale: f32) {
     %c16_i32 = arith.constant 16 : i32
 
-    %0 = ttc.generic (%scale) blocks [%c16_i32 : i32] attributes {tileShape = array<i32: 4>} body {
+    %0 = ttc.generic (%scale) blocks [%c16_i32 : i32] attributes {tileShape = array<i32: 4>, reductionDims = array<i32>} body {
       ^bb0(%offset: i32, %s: f32):
         %cst = arith.constant dense<1.0> : tensor<4xf32, #blocked>
         %splat = tt.splat %s : f32 -> tensor<4xf32, #blocked>
         %result = arith.mulf %cst, %splat : tensor<4xf32, #blocked>
         ttc.yield %result : tensor<4xf32, #blocked>
-    } combiners {} : (f32) -> tensor<16xf32, #blocked>
+    } : (f32) -> tensor<16xf32, #blocked>
     tt.return
   }
 }
@@ -40,13 +40,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @scale_2d(%scale: f32) {
     %c4_i32 = arith.constant 4 : i32
     %c8_i32 = arith.constant 8 : i32
-    %0 = ttc.generic (%scale) blocks [%c4_i32, %c8_i32 : i32, i32] attributes {tileShape = array<i32: 1, 4>} body {
+    %0 = ttc.generic (%scale) blocks [%c4_i32, %c8_i32 : i32, i32] attributes {tileShape = array<i32: 1, 4>, reductionDims = array<i32>} body {
       ^bb0(%dim0: i32, %dim1: i32, %s: f32):
         %cst = arith.constant dense<1.0> : tensor<1x4xf32, #blocked>
         %splat = tt.splat %s : f32 -> tensor<1x4xf32, #blocked>
         %result = arith.mulf %cst, %splat : tensor<1x4xf32, #blocked>
         ttc.yield %result : tensor<1x4xf32, #blocked>
-    } combiners {} : (f32) -> tensor<4x8xf32, #blocked>
+    } : (f32) -> tensor<4x8xf32, #blocked>
     tt.return
   }
 }
@@ -63,13 +63,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @scale_3d(%scale: f32) {
     %c4_i32 = arith.constant 4 : i32
     %c8_i32 = arith.constant 8 : i32
-    %0 = ttc.generic (%scale) blocks [%c4_i32, %c4_i32, %c8_i32 : i32, i32, i32] attributes {tileShape = array<i32: 1, 1, 4>} body {
+    %0 = ttc.generic (%scale) blocks [%c4_i32, %c4_i32, %c8_i32 : i32, i32, i32] attributes {tileShape = array<i32: 1, 1, 4>, reductionDims = array<i32>} body {
       ^bb0(%dim0: i32, %dim1: i32, %dim2: i32, %s: f32):
         %cst = arith.constant dense<1.0> : tensor<1x1x4xf32, #blocked>
         %splat = tt.splat %s : f32 -> tensor<1x1x4xf32, #blocked>
         %result = arith.mulf %cst, %splat : tensor<1x1x4xf32, #blocked>
         ttc.yield %result : tensor<1x1x4xf32, #blocked>
-    } combiners {} : (f32) -> tensor<4x4x8xf32, #blocked>
+    } : (f32) -> tensor<4x4x8xf32, #blocked>
     tt.return
   }
 }
@@ -87,13 +87,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %c2_i32 = arith.constant 2 : i32
     %c4_i32 = arith.constant 4 : i32
     %c8_i32 = arith.constant 8 : i32
-    %0 = ttc.generic (%scale) blocks [%c2_i32, %c2_i32, %c4_i32, %c8_i32 : i32, i32, i32, i32] attributes {tileShape = array<i32: 1, 1, 1, 4>} body {
+    %0 = ttc.generic (%scale) blocks [%c2_i32, %c2_i32, %c4_i32, %c8_i32 : i32, i32, i32, i32] attributes {tileShape = array<i32: 1, 1, 1, 4>, reductionDims = array<i32>} body {
       ^bb0(%dim0: i32, %dim1: i32, %dim2: i32, %dim3: i32, %s: f32):
         %cst = arith.constant dense<1.0> : tensor<1x1x1x4xf32, #blocked>
         %splat = tt.splat %s : f32 -> tensor<1x1x1x4xf32, #blocked>
         %result = arith.mulf %cst, %splat : tensor<1x1x1x4xf32, #blocked>
         ttc.yield %result : tensor<1x1x1x4xf32, #blocked>
-    } combiners {} : (f32) -> tensor<2x2x4x8xf32, #blocked>
+    } : (f32) -> tensor<2x2x4x8xf32, #blocked>
     tt.return
   }
 }


### PR DESCRIPTION
Previously, when handling reductions between tiles captured in a `ttc.generic` loop nest we used a special region called "combiners" to determine how to handle reductions between tiles. This was expedient for prototyping but is not really in the spirit of preserving the existing semantics of MLIR dialects that we use. This PR changes the generic op to capture variables that need to be tracked between tiles as `iter_args`. The logic for updating the tier arg post computation is moved into the main generic op body, and each tile outputs a fully reduced result (up to the location of that tile in the loop). 

This allows us to simplify the lowering to have only two cases - generic ops where we unroll the generic loop over tiles, and generic ops where we generate a dynamic loop nest. Both cases support iter args / reductions, now. The iter arg logic could probably use a cleanup pass in the LLVM lowering, but I focused on 1:1 replacement and correctness for this PR to try and keep the diff simple. 

I intend to use this to support tiling the K loop so we can generate a K -> M -> N loop nest over the existing block dimensions, and then run the matmul at tile granularity in each dimension. In that work I will handle updating `FuseParentForOp` to support iter args -it doesn't, right now, but they're currently never used in that case.

