### PR TITLE
Canonicalize K loop structures over `tt.dot` for generic op fusion

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -142,9 +142,9 @@ class CPUBackend(BaseBackend):
         else:
             cpu.passes.ttgpuir.add_coalesce(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
-        if options.tile_and_fuse is False:
-            cpu.passes.ttgpuir.add_accelerate_matmul(pm)
-            passes.ttgpuir.add_remove_layout_conversions(pm)
+        cpu.passes.ttgpuir.add_accelerate_matmul(pm, optimize_block_layout=not options.tile_and_fuse,
+                                                 canonicalize_k_loop=options.tile_and_fuse)
+        passes.ttgpuir.add_remove_layout_conversions(pm)
 
         passes.ttgpuir.add_optimize_thread_locality(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)

--- a/cpu/include/Dialect/TritonCPU/Transforms/Passes.td
+++ b/cpu/include/Dialect/TritonCPU/Transforms/Passes.td
@@ -8,8 +8,22 @@ def TritonCPUAccelerateMatmul : Pass<"tritoncpu-accelerate-matmul", "mlir::Modul
 
   let description = [{
     Optimize the input/output layout of `dot` instruction to make them compatible hardware accelerators
-    (e.g., Nvidia tensor cores)
+    (e.g., Nvidia tensor cores).
+
+    Optionally rewrites block layout for improved memory access patterns
+    (`optimize-block-layout`), and canonicalizes K-loop pointer iter args into
+    direct per-iteration computations to enable K-loop fusion (`canonicalize-k-loop`).
   }];
+
+  let options = [
+    Option<"optimizeBlockLayout", "optimize-block-layout", "bool",
+           /*default=*/"false",
+           "Rewrite tensor block layouts for improved memory access patterns">,
+    Option<"canonicalizeKLoop", "canonicalize-k-loop", "bool",
+           /*default=*/"false",
+           "Canonicalize K-loop pointer iter args to direct per-iteration "
+           "addptr(init, iv * step) computations, enabling K-loop fusion">,
+  ];
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
                            "mlir::triton::TritonDialect"];

--- a/cpu/include/Dialect/TritonCPU/Transforms/Passes.td
+++ b/cpu/include/Dialect/TritonCPU/Transforms/Passes.td
@@ -25,7 +25,9 @@ def TritonCPUAccelerateMatmul : Pass<"tritoncpu-accelerate-matmul", "mlir::Modul
            "addptr(init, iv * step) computations, enabling K-loop fusion">,
   ];
 
-  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+  let dependentDialects = ["mlir::arith::ArithDialect",
+                           "mlir::scf::SCFDialect",
+                           "mlir::triton::gpu::TritonGPUDialect",
                            "mlir::triton::TritonDialect"];
 }
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/AccelerateMatmul.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/AccelerateMatmul.cpp
@@ -198,6 +198,7 @@ public:
     // checked below)
 
     // create a new scf.for with only the accumulator iter arg
+    rewriter.setInsertionPoint(forOp);
     auto newFor = scf::ForOp::create(
         rewriter, forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
         forOp.getStep(),
@@ -228,7 +229,8 @@ public:
     Value kIV = newFor.getInductionVar();
 
     IRMapping mapping;
-    mapping.map(kIV, newFor.getInductionVar());
+    mapping.map(forOp.getInductionVar(), kIV);
+    mapping.map(c, newFor.getRegionIterArg(0));
     auto rewriteAddPtrForOperand = [&](Value operand, BlockArgument iterArg,
                                        triton::AddPtrOp addPtr) {
       Value initValue = forOp.getInitArgs()[iterArg.getArgNumber() -
@@ -258,9 +260,9 @@ public:
         continue; // already rewritten
       rewriter.clone(op, mapping);
     }
-  
-    // auto oldYield = cast<scf::YieldOp>(newFor.getBody()->getTerminator());
-    scf::YieldOp::create(rewriter, newFor.getLoc(), ValueRange{d});
+
+    scf::YieldOp::create(rewriter, newFor.getLoc(),
+                         ValueRange{mapping.lookup(d)});
 
     for (auto [i, result] : llvm::enumerate(forOp.getResults())) {
       if (i == c.getArgNumber() - forOp.getNumInductionVars()) {
@@ -272,7 +274,7 @@ public:
         }
       }
     }
-    // rewriter.eraseOp(forOp);
+    rewriter.eraseOp(forOp);
     return success();
   }
 };

--- a/cpu/lib/Dialect/TritonCPU/Transforms/AccelerateMatmul.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/AccelerateMatmul.cpp
@@ -221,12 +221,14 @@ public:
     }
 
     // rewrite existing loop body before merging into the new loop
-    rewriter.setInsertionPointToStart(forOp.getBody());
+    rewriter.setInsertionPointToStart(newFor.getBody());
 
     // rewrite each dot operand to feed from the for loop induction variable by
     // computing the add ptr value directly
-    Value kIV = forOp.getInductionVar();
+    Value kIV = newFor.getInductionVar();
 
+    IRMapping mapping;
+    mapping.map(kIV, newFor.getInductionVar());
     auto rewriteAddPtrForOperand = [&](Value operand, BlockArgument iterArg,
                                        triton::AddPtrOp addPtr) {
       Value initValue = forOp.getInitArgs()[iterArg.getArgNumber() -
@@ -241,7 +243,8 @@ public:
           arith::MulIOp::create(rewriter, offset.getLoc(), kSplat, offset);
       auto newAddPtr = triton::AddPtrOp::create(
           rewriter, addPtr.getLoc(), initValue.getType(), initValue, newOffset);
-      rewriter.replaceAllUsesWith(iterArg, newAddPtr.getResult());
+      // rewriter.replaceAllUsesWith(iterArg, newAddPtr.getResult());
+      mapping.map(iterArg, newAddPtr.getResult());
     };
 
     rewriteAddPtrForOperand(dotOp.getA(), aMatchResult->first,
@@ -249,15 +252,19 @@ public:
     rewriteAddPtrForOperand(dotOp.getB(), bMatchResult->first,
                             bMatchResult->second);
 
-    rewriter.mergeBlocks(forOp.getBody(), newFor.getBody(),
-                         newForRegionArgValues);
-
-    auto oldYield = cast<scf::YieldOp>(newFor.getBody()->getTerminator());
-    rewriter.replaceOpWithNewOp<scf::YieldOp>(oldYield, ValueRange{d});
+    for (auto &op : forOp.getBody()->without_terminator()) {
+      if (&op == aMatchResult->second.getOperation() ||
+          &op == bMatchResult->second.getOperation())
+        continue; // already rewritten
+      rewriter.clone(op, mapping);
+    }
+  
+    // auto oldYield = cast<scf::YieldOp>(newFor.getBody()->getTerminator());
+    scf::YieldOp::create(rewriter, newFor.getLoc(), ValueRange{d});
 
     for (auto [i, result] : llvm::enumerate(forOp.getResults())) {
       if (i == c.getArgNumber() - forOp.getNumInductionVars()) {
-        result.replaceAllUsesWith(newFor.getResult(0));
+        rewriter.replaceAllUsesWith(result, newFor.getResult(0));
       } else {
         if (!result.use_empty()) {
           llvm_unreachable(
@@ -265,7 +272,7 @@ public:
         }
       }
     }
-    rewriter.eraseOp(forOp);
+    // rewriter.eraseOp(forOp);
     return success();
   }
 };

--- a/cpu/lib/Dialect/TritonCPU/Transforms/AccelerateMatmul.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/AccelerateMatmul.cpp
@@ -1,8 +1,11 @@
 #include "cpu/include/Dialect/TritonCPU/Transforms/Passes.h"
 
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/Support/Debug.h"
 
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
@@ -84,6 +87,189 @@ public:
   }
 };
 
+// Walk backward from dotOp.getA() through optional convert_layout + load +
+// optional convert_layout to find the for-loop iter arg that feeds the A
+// pointer. Validates that the iter arg:
+//   (a) is a tensor-of-pointers block arg belonging to forOp
+//   (b) has exactly one tt.addptr user (iter arg as ptr, loop-invariant offset,
+//       result feeds scf.yield)
+//   (c) has no unexpected users beyond convert_layout / tt.load ops
+// Returns {iterArg, addptrOp} on success, nullopt on failure.
+static std::optional<std::pair<BlockArgument, triton::AddPtrOp>>
+matchAPtrIterArg(Value val, scf::ForOp forOp) {
+  if (auto cvt = val.getDefiningOp<gpu::ConvertLayoutOp>())
+    val = cvt.getOperand();
+  auto load = val.getDefiningOp<triton::LoadOp>();
+  if (!load)
+    return std::nullopt;
+
+  Value ptr = load.getPtr();
+  if (auto cvt = ptr.getDefiningOp<gpu::ConvertLayoutOp>())
+    ptr = cvt.getOperand();
+  auto iterArg = dyn_cast<BlockArgument>(ptr);
+  if (!iterArg || iterArg.getOwner() != forOp.getBody())
+    return std::nullopt;
+  auto tensorTy = dyn_cast<RankedTensorType>(iterArg.getType());
+  if (!tensorTy || !isa<triton::PointerType>(tensorTy.getElementType()))
+    return std::nullopt;
+
+  // Validate forward uses of the iter arg.
+  triton::AddPtrOp addptr;
+  for (Operation *user : iterArg.getUsers()) {
+    if (auto ap = dyn_cast<triton::AddPtrOp>(user)) {
+      if (addptr || ap.getPtr() != iterArg)
+        return std::nullopt;
+      if (!forOp.isDefinedOutsideOfLoop(ap.getOffset()))
+        return std::nullopt;
+      addptr = ap;
+    } else if (!isa<gpu::ConvertLayoutOp, triton::LoadOp>(user)) {
+      return std::nullopt;
+    }
+  }
+  if (!addptr)
+    return std::nullopt;
+  if (!addptr.getResult().hasOneUse())
+    return std::nullopt;
+
+  // addptr result must feed into scf.yield.
+  auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+  if (!llvm::is_contained(yield.getOperands(), addptr.getResult()))
+    return std::nullopt;
+
+  return std::make_pair(iterArg, addptr);
+}
+
+class CanonicalizeKLoop : public mlir::OpRewritePattern<DotOp> {
+public:
+  CanonicalizeKLoop(mlir::MLIRContext *context, int benefit)
+      : OpRewritePattern<DotOp>(context, benefit) {}
+
+  LogicalResult
+  matchAndRewrite(triton::DotOp dotOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    // look for parent for op with appropriate conditions for canonicalization.
+    // Namely, we want a loop carried accumulator and additional iter args that
+    // only correspond to ptr arithmetic that is easily re-mapped
+
+    auto forOp = dotOp->getParentOfType<scf::ForOp>();
+    if (!forOp)
+      return failure();
+    if (!matchPattern(forOp.getStep(), m_One()))
+      return failure();
+
+    // is the accumulator loop carried?
+    auto c = dyn_cast<BlockArgument>(dotOp.getC());
+    if (!c)
+      return failure();
+    if (!c.hasOneUse())
+      return failure();
+    auto accParent = c.getOwner()->getParentOp();
+    if (accParent != forOp)
+      return failure();
+
+    auto d = dotOp.getD();
+    // d must feed scf.yield at the same position that c comes from, ensuring
+    // the accumulator round-trips through the iter arg at a consistent index.
+    unsigned accIdx = c.getArgNumber() - forOp.getNumInductionVars();
+    auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    if (yield.getOperand(accIdx) != d)
+      return failure();
+
+    auto aMatchResult = matchAPtrIterArg(dotOp.getA(), forOp);
+    if (!aMatchResult)
+      return failure();
+    auto bMatchResult = matchAPtrIterArg(dotOp.getB(), forOp);
+    if (!bMatchResult)
+      return failure();
+
+    // loop carried ptr args must not be used by for op users
+    if (!forOp
+             .getResult(aMatchResult->first.getArgNumber() -
+                        forOp.getNumInductionVars())
+             .use_empty())
+      return failure();
+    if (!forOp
+             .getResult(bMatchResult->first.getArgNumber() -
+                        forOp.getNumInductionVars())
+             .use_empty())
+      return failure();
+
+    // matching complete, we can rewrite the loop (assuming no iter arg spills,
+    // checked below)
+
+    // create a new scf.for with only the accumulator iter arg
+    auto newFor = scf::ForOp::create(
+        rewriter, forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
+        forOp.getStep(),
+        ValueRange{forOp.getInitArgs()[c.getArgNumber() -
+                                       forOp.getNumInductionVars()]});
+
+    SmallVector<Value> newForRegionArgValues;
+    newForRegionArgValues.push_back(newFor.getInductionVar());
+    for (auto arg : forOp.getRegionIterArgs()) {
+      if (arg == c) {
+        newForRegionArgValues.push_back(newFor.getRegionIterArg(0));
+      } else {
+        // if not a ptr arg fail
+        if (!llvm::is_contained({aMatchResult->first, bMatchResult->first},
+                                arg))
+          return failure();
+        // arg replacement will not be used (uses already cleared by
+        // replaceAllUsesWith)
+        newForRegionArgValues.push_back(newFor.getInductionVar());
+      }
+    }
+
+    // rewrite existing loop body before merging into the new loop
+    rewriter.setInsertionPointToStart(forOp.getBody());
+
+    // rewrite each dot operand to feed from the for loop induction variable by
+    // computing the add ptr value directly
+    Value kIV = forOp.getInductionVar();
+
+    auto rewriteAddPtrForOperand = [&](Value operand, BlockArgument iterArg,
+                                       triton::AddPtrOp addPtr) {
+      Value initValue = forOp.getInitArgs()[iterArg.getArgNumber() -
+                                            forOp.getNumInductionVars()];
+
+      // rewrite addptr to compute the pointer for the current loop iteration:
+      // new_addptr = iterArg + splat(kIV) * offset
+      auto offset = addPtr.getOffset();
+      Value kSplat = triton::SplatOp::create(rewriter, addPtr.getLoc(),
+                                             offset.getType(), kIV);
+      Value newOffset =
+          arith::MulIOp::create(rewriter, offset.getLoc(), kSplat, offset);
+      auto newAddPtr = triton::AddPtrOp::create(
+          rewriter, addPtr.getLoc(), initValue.getType(), initValue, newOffset);
+      rewriter.replaceAllUsesWith(iterArg, newAddPtr.getResult());
+    };
+
+    rewriteAddPtrForOperand(dotOp.getA(), aMatchResult->first,
+                            aMatchResult->second);
+    rewriteAddPtrForOperand(dotOp.getB(), bMatchResult->first,
+                            bMatchResult->second);
+
+    rewriter.mergeBlocks(forOp.getBody(), newFor.getBody(),
+                         newForRegionArgValues);
+
+    auto oldYield = cast<scf::YieldOp>(newFor.getBody()->getTerminator());
+    rewriter.replaceOpWithNewOp<scf::YieldOp>(oldYield, ValueRange{d});
+
+    for (auto [i, result] : llvm::enumerate(forOp.getResults())) {
+      if (i == c.getArgNumber() - forOp.getNumInductionVars()) {
+        result.replaceAllUsesWith(newFor.getResult(0));
+      } else {
+        if (!result.use_empty()) {
+          llvm_unreachable(
+              "unexpected use of non-accumulator loop carried value");
+        }
+      }
+    }
+    rewriter.eraseOp(forOp);
+    return success();
+  }
+};
+
 } // namespace
 
 class TritonCPUAccelerateMatmulPass
@@ -98,7 +284,12 @@ public:
     ModuleOp m = getOperation();
     mlir::RewritePatternSet patterns(context);
     constexpr int benefitDefault = 1;
-    patterns.add<OptimizeBlockedLayout>(context, benefitDefault);
+    if (optimizeBlockLayout) {
+      patterns.add<OptimizeBlockedLayout>(context, benefitDefault);
+    }
+    if (canonicalizeKLoop) {
+      patterns.add<CanonicalizeKLoop>(context, benefitDefault);
+    }
     if (applyPatternsGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();
     }

--- a/cpu/lib/Dialect/TritonCPU/Transforms/AccelerateMatmul.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/AccelerateMatmul.cpp
@@ -205,22 +205,6 @@ public:
         ValueRange{forOp.getInitArgs()[c.getArgNumber() -
                                        forOp.getNumInductionVars()]});
 
-    SmallVector<Value> newForRegionArgValues;
-    newForRegionArgValues.push_back(newFor.getInductionVar());
-    for (auto arg : forOp.getRegionIterArgs()) {
-      if (arg == c) {
-        newForRegionArgValues.push_back(newFor.getRegionIterArg(0));
-      } else {
-        // if not a ptr arg fail
-        if (!llvm::is_contained({aMatchResult->first, bMatchResult->first},
-                                arg))
-          return failure();
-        // arg replacement will not be used (uses already cleared by
-        // replaceAllUsesWith)
-        newForRegionArgValues.push_back(newFor.getInductionVar());
-      }
-    }
-
     // rewrite existing loop body before merging into the new loop
     rewriter.setInsertionPointToStart(newFor.getBody());
 
@@ -231,8 +215,7 @@ public:
     IRMapping mapping;
     mapping.map(forOp.getInductionVar(), kIV);
     mapping.map(c, newFor.getRegionIterArg(0));
-    auto rewriteAddPtrForOperand = [&](Value operand, BlockArgument iterArg,
-                                       triton::AddPtrOp addPtr) {
+    auto rewriteAddPtr = [&](BlockArgument iterArg, triton::AddPtrOp addPtr) {
       Value initValue = forOp.getInitArgs()[iterArg.getArgNumber() -
                                             forOp.getNumInductionVars()];
 
@@ -249,10 +232,8 @@ public:
       mapping.map(iterArg, newAddPtr.getResult());
     };
 
-    rewriteAddPtrForOperand(dotOp.getA(), aMatchResult->first,
-                            aMatchResult->second);
-    rewriteAddPtrForOperand(dotOp.getB(), bMatchResult->first,
-                            bMatchResult->second);
+    rewriteAddPtr(aMatchResult->first, aMatchResult->second);
+    rewriteAddPtr(bMatchResult->first, bMatchResult->second);
 
     for (auto &op : forOp.getBody()->without_terminator()) {
       if (&op == aMatchResult->second.getOperation() ||

--- a/test/Transform/accelerate_matmul.mlir
+++ b/test/Transform/accelerate_matmul.mlir
@@ -1,0 +1,48 @@
+// RUN: triton-opt %s -split-input-file --tritoncpu-accelerate-matmul="canonicalize-k-loop=true" | FileCheck %s
+
+// K-loop with two pointer iter args and an accumulator is rewritten to carry
+// only the accumulator; pointer arithmetic is inlined per iteration as
+// addptr(init, splat(iv) * step).
+//
+// CHECK-LABEL: tt.func public @test_canonicalize_k_loop
+// CHECK:         scf.for [[IV:%[^ ]+]] = {{.*}} iter_args([[ACC:%[^ ]+]] = {{.*}}) -> (tensor<4x16xf32
+// CHECK:           tt.splat [[IV]]
+// CHECK:           arith.muli
+// CHECK:           tt.addptr
+// CHECK:           tt.splat [[IV]]
+// CHECK:           arith.muli
+// CHECK:           tt.addptr
+// CHECK:           tt.dot {{.*}}[[ACC]]
+// CHECK:           scf.yield
+
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
+  tt.func public @test_canonicalize_k_loop(
+      %a_init: tensor<4x8x!tt.ptr<f16>, #blocked1>,
+      %b_init: tensor<8x16x!tt.ptr<f16>, #blocked1>,
+      %a_step: tensor<4x8xi32, #blocked1>,
+      %b_step: tensor<8x16xi32, #blocked1>,
+      %k_iters: i32,
+      %out: tensor<4x16x!tt.ptr<f32>, #blocked2>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %acc_init = arith.constant dense<0.0> : tensor<4x16xf32, #blocked2>
+    %result:3 = scf.for %k = %c0 to %k_iters step %c1
+        iter_args(%a_ptr = %a_init, %b_ptr = %b_init, %acc = %acc_init)
+        -> (tensor<4x8x!tt.ptr<f16>, #blocked1>,
+            tensor<8x16x!tt.ptr<f16>, #blocked1>,
+            tensor<4x16xf32, #blocked2>) : i32 {
+      %a_loaded = tt.load %a_ptr : tensor<4x8x!tt.ptr<f16>, #blocked1>
+      %b_loaded = tt.load %b_ptr : tensor<8x16x!tt.ptr<f16>, #blocked1>
+      %a_cvt = ttg.convert_layout %a_loaded : tensor<4x8xf16, #blocked1> -> tensor<4x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked2}>>
+      %b_cvt = ttg.convert_layout %b_loaded : tensor<8x16xf16, #blocked1> -> tensor<8x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked2}>>
+      %d = tt.dot %a_cvt, %b_cvt, %acc : tensor<4x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked2}>> * tensor<8x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked2}>> -> tensor<4x16xf32, #blocked2>
+      %a_next = tt.addptr %a_ptr, %a_step : tensor<4x8x!tt.ptr<f16>, #blocked1>, tensor<4x8xi32, #blocked1>
+      %b_next = tt.addptr %b_ptr, %b_step : tensor<8x16x!tt.ptr<f16>, #blocked1>, tensor<8x16xi32, #blocked1>
+      scf.yield %a_next, %b_next, %d : tensor<4x8x!tt.ptr<f16>, #blocked1>, tensor<8x16x!tt.ptr<f16>, #blocked1>, tensor<4x16xf32, #blocked2>
+    }
+    tt.store %out, %result#2 : tensor<4x16x!tt.ptr<f32>, #blocked2>
+    tt.return
+  }
+}

--- a/triton_cpu.cc
+++ b/triton_cpu.cc
@@ -38,9 +38,17 @@ void init_triton_cpu_passes(py::module &&m) {
 }
 
 void init_triton_cpu_passes_ttgpuir(py::module &&m) {
-  m.def("add_accelerate_matmul", [](mlir::PassManager &pm) {
-    pm.addPass(mlir::triton::cpu::createTritonCPUAccelerateMatmul());
-  });
+  m.def(
+      "add_accelerate_matmul",
+      [](mlir::PassManager &pm, bool optimizeBlockLayout,
+         bool canonicalizeKLoop) {
+        mlir::triton::cpu::TritonCPUAccelerateMatmulOptions opts;
+        opts.optimizeBlockLayout = optimizeBlockLayout;
+        opts.canonicalizeKLoop = canonicalizeKLoop;
+        pm.addPass(mlir::triton::cpu::createTritonCPUAccelerateMatmul(opts));
+      },
+      py::arg("pm"), py::arg("optimize_block_layout") = false,
+      py::arg("canonicalize_k_loop") = false);
   m.def("add_coalesce", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createTritonCPUCoalesce());
   });


### PR DESCRIPTION
Detect matmuls with loop carried accumulators + `a` and `b` operand ptrs and split the `a` and `b` operand ptrs from being loop carried to being computed per loop iteration using the K loop induction variable. This allows us to cleanly fuse the K loop into a generic loop in later stages. Since this is a form of matmul acceleration I opted to use the existing accelerate matmul framework with options set depending on whether or not tile and fuse is enabled. 