### PR TITLE
Refactor GenericOpToLLVM to use `ArgInfo` + `LoopHelper`

### DIFF
--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -46,6 +46,235 @@ static Value allocateGlobalBuffer(ConversionPatternRewriter &rewriter,
   return globalPtr;
 }
 
+struct ArgInfo {
+  enum class Kind { IV, IterArg, Ins };
+
+  ArgInfo(Kind k) : kind(k) {}
+  ArgInfo(Kind k, Type tritonType, Type llvmType)
+      : kind(k), tritonType(tritonType), llvmType(llvmType) {}
+
+  Kind kind;
+  Type tritonType;
+  Type llvmType;
+  Value operand;
+
+  Value bufferPtr;       // only for global memory backed args
+  unsigned numElems = 0; // only for global memory backed args
+  Value convertedArg; // only for non-alloca tensor args that need to be tiled
+                      // (unroll / static path)
+
+  bool requiresMaterialization() const {
+    return kind == Kind::Ins && isa<RankedTensorType>(tritonType) && !bufferPtr;
+  }
+};
+
+class LoopHelper {
+public:
+  LoopHelper(ArrayRef<ArgInfo> args, ArrayRef<Value> loopIterArgs,
+             Value flatOffset, cpu::GenericOp generic,
+             const TypeConverter *typeConverter,
+             ConversionPatternRewriter &rewriter);
+
+  SmallVector<Value> getEntryArgs() {
+    return {tileOffsets.begin(), tileOffsets.end()};
+  }
+
+  void addTileOffset(Value offset) { tileOffsets.push_back(offset); }
+  void setTileOffset(unsigned dim, Value offset) { tileOffsets[dim] = offset; }
+
+  void popTileOffset() { tileOffsets.pop_back(); }
+
+  void incrementFlatOffset(ConversionPatternRewriter &rewriter, Value inc) {
+    auto b = TritonLLVMOpBuilder(flatOffset.getLoc(), rewriter);
+    flatOffset = b.add(flatOffset, inc);
+  }
+
+  // build loop body block arguments for the current loop level. Adds
+  // arguments for loop induction vars, generic iter args, and generic
+  // operands. Handles extracting the appropriate tile for non-alloca tensor
+  // operands in the static (unrolled) path. Slices memory backed tensors into
+  // tiles (LLVM struct type).
+  SmallVector<Value>
+  getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter, unsigned vectorSize,
+                       std::optional<unsigned> loopIndex = std::nullopt);
+
+  // stores generic body tensor results into global memory buffers.
+  void scatterResults(ConversionPatternRewriter &rewriter,
+                      ArrayRef<Value> results, ArrayRef<Type> resultTypes,
+                      unsigned vectorSize);
+
+  void updateIterArgs(ArrayRef<Value> newIterArgVals) {
+    assert(newIterArgVals.size() == loopIterArgs.size());
+    for (auto [i, newVal] : llvm::enumerate(newIterArgVals))
+      loopIterArgs[i] = newVal;
+  }
+
+  SmallVector<Value> getIterArgVals() const { return loopIterArgs; }
+
+  SmallVector<Value> getResults() const {
+    SmallVector<Value> ret(loopIterArgs.begin(), loopIterArgs.end());
+    ret.append(materializedResults.begin(), materializedResults.end());
+    return ret;
+  }
+
+private:
+  SmallVector<ArgInfo> args;
+  SmallVector<Value> loopIterArgs;
+
+  SmallVector<Value> materializedResults;
+  SmallVector<Type> materializedResultElementTypes;
+
+  SmallVector<Value> tileOffsets;
+  Value flatOffset;
+};
+
+LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, ArrayRef<Value> loopIterArgs,
+                       Value flatOffset, cpu::GenericOp generic,
+                       const TypeConverter *typeConverter,
+                       ConversionPatternRewriter &rewriter)
+    : args(args.begin(), args.end()),
+      loopIterArgs(loopIterArgs.begin(), loopIterArgs.end()),
+      flatOffset(flatOffset) {
+
+  // Create temporary buffers in thread local global memory for materialized
+  // results. This avoids loop-carried <blockSize x elemTy> phi nodes
+  // which would allocate tens of kilobytes on the stack and cause stack
+  // overflows for large block sizes (e.g. blockSize=4096).
+  //
+  // Globals are addressed via AddressOf in the function entry block so the
+  // pointer dominates all uses. Each thread gets its own copy since the
+  // globals are thread-local.
+  //
+  // TODO: we should probably check that generic results are only used by
+  // other generics or we will run into conversion problems
+  for (auto [i, resultTy] : llvm::enumerate(llvm::drop_begin(
+           generic.getResultTypes(), generic.getNumIterArgs()))) {
+    auto tensorTy = cast<RankedTensorType>(resultTy);
+    int64_t tensorElems =
+        std::accumulate(tensorTy.getShape().begin(), tensorTy.getShape().end(),
+                        int64_t{1}, std::multiplies<>());
+    Type elemTy = typeConverter->convertType(tensorTy.getElementType());
+    materializedResultElementTypes.push_back(elemTy);
+
+    Value globalPtr = allocateGlobalBuffer(
+        rewriter, generic.getResult(i + generic.getNumIterArgs()).getLoc(),
+        elemTy, tensorElems, materializedResults.size(), generic);
+    materializedResults.push_back(globalPtr);
+  }
+}
+
+SmallVector<Value> LoopHelper::getLoopBodyBlockArgs(
+    ConversionPatternRewriter &rewriter, unsigned vectorSize,
+    std::optional<unsigned> loopIndex) {
+  // start with IVs
+  SmallVector<Value> blockArgs = {tileOffsets.begin(), tileOffsets.end()};
+
+  // iter args
+  blockArgs.append(loopIterArgs.begin(), loopIterArgs.end());
+
+  // Add ins args
+  for (const auto &argInfo : args) {
+    if (argInfo.kind == ArgInfo::Kind::Ins) {
+      Location loc = argInfo.operand.getLoc();
+
+      // if we are in the static (unrolled) path, we need to handle
+      // non-alloca tensor args by extracting the appropriate chunk for this
+      // iteration.
+      if (loopIndex.has_value()) {
+        auto tensorTy = dyn_cast<RankedTensorType>(argInfo.tritonType);
+        if (tensorTy && !argInfo.bufferPtr) {
+          assert(argInfo.convertedArg && "expected adaptor-converted arg "
+                                         "for non-alloca tensor operand");
+          auto tileStructTy = cast<LLVM::LLVMStructType>(argInfo.llvmType);
+          Value tile = LLVM::UndefOp::create(rewriter, loc, tileStructTy);
+          TritonLLVMOpBuilder b(argInfo.operand.getLoc(), rewriter);
+
+          for (unsigned j = 0; j < vectorSize; ++j) {
+            int64_t srcIndex = loopIndex.value() * vectorSize + j;
+            LDBG("Read " << srcIndex);
+            Value extractedElement = b.extract_val(
+                tileStructTy.getBody()[j], argInfo.convertedArg, srcIndex);
+            tile = b.insert_val(tileStructTy, tile, extractedElement, j);
+          }
+
+          Value castedTile = UnrealizedConversionCastOp::create(
+                                 rewriter, loc, argInfo.tritonType, tile)
+                                 .getResult(0);
+          blockArgs.push_back(castedTile);
+          continue;
+        }
+      }
+
+      if (argInfo.bufferPtr) {
+        // load this tiles elements from the global buffer
+        auto tileStructTy = cast<LLVM::LLVMStructType>(argInfo.llvmType);
+        Type elemTy = tileStructTy.getBody()[0];
+        Value tileStruct = LLVM::UndefOp::create(rewriter, loc, tileStructTy);
+        auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+        // TODO: should this be vectorSize?
+        for (unsigned j = 0; j < vectorSize; ++j) {
+          // TODO: use builder
+          Value globalIdx =
+              LLVM::AddOp::create(rewriter, loc, flatOffset, b.i32_val(j));
+          Value gep = LLVM::GEPOp::create(
+              rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext()),
+              elemTy, argInfo.bufferPtr, ValueRange{globalIdx});
+          Value elem = LLVM::LoadOp::create(rewriter, loc, elemTy, gep);
+          tileStruct =
+              LLVM::InsertValueOp::create(rewriter, loc, tileStruct, elem, {j});
+        }
+        blockArgs.push_back(tileStruct);
+      } else if (isa<PointerType>(argInfo.tritonType)) {
+        // we might have a tt.ptr hiding in an unrealized conversion cast
+        // due to late conversion of generic op block arguments. Use
+        // unrealized conversion cast which will be folded away later
+        if (argInfo.tritonType != argInfo.llvmType) {
+          blockArgs.push_back(
+              UnrealizedConversionCastOp::create(
+                  rewriter, loc, argInfo.llvmType, argInfo.operand)
+                  .getResult(0));
+        } else {
+          blockArgs.push_back(argInfo.operand);
+        }
+      } else {
+        assert(!isa<RankedTensorType>(argInfo.tritonType));
+        assert(argInfo.tritonType == argInfo.llvmType &&
+               "expected non-tensor arguments to be unchanged by type "
+               "conversion");
+        blockArgs.push_back(argInfo.operand);
+      }
+    }
+  }
+
+  return blockArgs;
+}
+
+void LoopHelper::scatterResults(ConversionPatternRewriter &rewriter,
+                                ArrayRef<Value> results,
+                                ArrayRef<Type> resultTypes,
+                                unsigned vectorSize) {
+  for (auto [tile, tileType, ptr, elemTy] :
+       llvm::zip(results, resultTypes, materializedResults,
+                 materializedResultElementTypes)) {
+    Location loc = tile.getLoc(); // or ptr?
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto llvmStruct = cast<LLVM::LLVMStructType>(tileType);
+    Value llvmTile =
+        UnrealizedConversionCastOp::create(rewriter, loc, tileType, tile)
+            .getResult(0);
+    // TODO: should this be vector size or should we read the number of
+    // elements from the tile struct?
+    for (unsigned j = 0; j < vectorSize; ++j) {
+      Value elem = b.extract_val(llvmStruct.getBody()[j], llvmTile, j);
+      Value idx = b.add(flatOffset, b.i32_val(j));
+      Value gep =
+          b.gep(ptr_ty(rewriter.getContext()), elemTy, ptr, ValueRange{idx});
+      b.store(elem, gep);
+    }
+  }
+}
+
 struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
   using ConvertOpToLLVMPattern<cpu::GenericOp>::ConvertOpToLLVMPattern;
 
@@ -79,222 +308,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
            "type (alloca)");
     return castOp.getInputs()[0];
   }
-
-  struct ArgInfo {
-    enum class Kind { IV, IterArg, Ins };
-
-    ArgInfo(Kind k) : kind(k) {}
-    ArgInfo(Kind k, Type tritonType, Type llvmType)
-        : kind(k), tritonType(tritonType), llvmType(llvmType) {}
-
-    Kind kind;
-    Type tritonType;
-    Type llvmType;
-    Value operand;
-
-    Value bufferPtr;       // only for global memory backed args
-    unsigned numElems = 0; // only for global memory backed args
-    Value convertedArg; // only for non-alloca tensor args that need to be tiled
-                        // (unroll / static path)
-
-    bool requiresMaterialization() const {
-      return kind == Kind::Ins && isa<RankedTensorType>(tritonType) &&
-             !bufferPtr;
-    }
-  };
-
-  class LoopHelper {
-  public:
-    LoopHelper(ArrayRef<ArgInfo> args, ArrayRef<Value> loopIterArgs,
-               Value flatOffset, cpu::GenericOp generic,
-               const TypeConverter *typeConverter,
-               ConversionPatternRewriter &rewriter)
-        : args(args.begin(), args.end()),
-          loopIterArgs(loopIterArgs.begin(), loopIterArgs.end()),
-          flatOffset(flatOffset) {
-
-      // Create temporary buffers in thread local global memory for materialized
-      // results. This avoids loop-carried <blockSize x elemTy> phi nodes
-      // which would allocate tens of kilobytes on the stack and cause stack
-      // overflows for large block sizes (e.g. blockSize=4096).
-      //
-      // Globals are addressed via AddressOf in the function entry block so the
-      // pointer dominates all uses. Each thread gets its own copy since the
-      // globals are thread-local.
-      //
-      // TODO: we should probably check that generic results are only used by
-      // other generics or we will run into conversion problems
-      for (auto [i, resultTy] : llvm::enumerate(llvm::drop_begin(
-               generic.getResultTypes(), generic.getNumIterArgs()))) {
-        auto tensorTy = cast<RankedTensorType>(resultTy);
-        int64_t tensorElems = std::accumulate(tensorTy.getShape().begin(),
-                                              tensorTy.getShape().end(),
-                                              int64_t{1}, std::multiplies<>());
-        Type elemTy = typeConverter->convertType(tensorTy.getElementType());
-        materializedResultElementTypes.push_back(elemTy);
-
-        Value globalPtr = allocateGlobalBuffer(
-            rewriter, generic.getResult(i + generic.getNumIterArgs()).getLoc(),
-            elemTy, tensorElems, materializedResults.size(), generic);
-        materializedResults.push_back(globalPtr);
-      }
-    }
-
-    SmallVector<Value> getEntryArgs() {
-      return {tileOffsets.begin(), tileOffsets.end()};
-    }
-
-    void addTileOffset(Value offset) { tileOffsets.push_back(offset); }
-    void setTileOffset(unsigned dim, Value offset) {
-      tileOffsets[dim] = offset;
-    }
-
-    void popTileOffset() { tileOffsets.pop_back(); }
-
-    // todo: rename incrementOffset?
-    void updateFlatOffset(ConversionPatternRewriter &rewriter, Value inc) {
-      auto b = TritonLLVMOpBuilder(flatOffset.getLoc(), rewriter);
-      flatOffset = b.add(flatOffset, inc);
-    }
-
-    SmallVector<Value>
-    getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
-                         unsigned vectorSize,
-                         std::optional<unsigned> loopIndex = std::nullopt) {
-      // start with IVs
-      SmallVector<Value> blockArgs = {tileOffsets.begin(), tileOffsets.end()};
-
-      // iter args
-      blockArgs.append(loopIterArgs.begin(), loopIterArgs.end());
-
-      // Add ins args
-      for (const auto &argInfo : args) {
-        if (argInfo.kind == ArgInfo::Kind::Ins) {
-          Location loc = argInfo.operand.getLoc();
-
-          // if we are in the static (unrolled) path, we need to handle
-          // non-alloca tensor args by extracting the appropriate chunk for this
-          // iteration.
-          if (loopIndex.has_value()) {
-            auto tensorTy = dyn_cast<RankedTensorType>(argInfo.tritonType);
-            if (tensorTy && !argInfo.bufferPtr) {
-              assert(argInfo.convertedArg && "expected adaptor-converted arg "
-                                             "for non-alloca tensor operand");
-              auto tileStructTy = cast<LLVM::LLVMStructType>(argInfo.llvmType);
-              Value tile = LLVM::UndefOp::create(rewriter, loc, tileStructTy);
-              TritonLLVMOpBuilder b(argInfo.operand.getLoc(), rewriter);
-
-              for (unsigned j = 0; j < vectorSize; ++j) {
-                int64_t srcIndex = loopIndex.value() * vectorSize + j;
-                LDBG("Read " << srcIndex);
-                Value extractedElement = b.extract_val(
-                    tileStructTy.getBody()[j], argInfo.convertedArg, srcIndex);
-                tile = b.insert_val(tileStructTy, tile, extractedElement, j);
-              }
-
-              Value castedTile = UnrealizedConversionCastOp::create(
-                                     rewriter, loc, argInfo.tritonType, tile)
-                                     .getResult(0);
-              blockArgs.push_back(castedTile);
-              continue;
-            }
-          }
-
-          if (argInfo.bufferPtr) {
-            // load this tiles elements from the global buffer
-            auto tileStructTy = cast<LLVM::LLVMStructType>(argInfo.llvmType);
-            Type elemTy = tileStructTy.getBody()[0];
-            Value tileStruct =
-                LLVM::UndefOp::create(rewriter, loc, tileStructTy);
-            auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-            // TODO: should this be vectorSize?
-            for (unsigned j = 0; j < vectorSize; ++j) {
-              // TODO: use builder
-              Value globalIdx =
-                  LLVM::AddOp::create(rewriter, loc, flatOffset, b.i32_val(j));
-              Value gep = LLVM::GEPOp::create(
-                  rewriter, loc,
-                  LLVM::LLVMPointerType::get(rewriter.getContext()), elemTy,
-                  argInfo.bufferPtr, ValueRange{globalIdx});
-              Value elem = LLVM::LoadOp::create(rewriter, loc, elemTy, gep);
-              tileStruct = LLVM::InsertValueOp::create(rewriter, loc,
-                                                       tileStruct, elem, {j});
-            }
-            blockArgs.push_back(tileStruct);
-          } else if (isa<PointerType>(argInfo.tritonType)) {
-            // we might have a tt.ptr hiding in an unrealized conversion cast
-            // due to late conversion of generic op block arguments. Use
-            // unrealized conversion cast which will be folded away later
-            if (argInfo.tritonType != argInfo.llvmType) {
-              blockArgs.push_back(
-                  UnrealizedConversionCastOp::create(
-                      rewriter, loc, argInfo.llvmType, argInfo.operand)
-                      .getResult(0));
-            } else {
-              blockArgs.push_back(argInfo.operand);
-            }
-          } else {
-            assert(!isa<RankedTensorType>(argInfo.tritonType));
-            assert(argInfo.tritonType == argInfo.llvmType &&
-                   "expected non-tensor arguments to be unchanged by type "
-                   "conversion");
-            blockArgs.push_back(argInfo.operand);
-          }
-        }
-      }
-
-      return blockArgs;
-    }
-
-    void scatterResults(ConversionPatternRewriter &rewriter,
-                        ArrayRef<Value> results, ArrayRef<Type> resultTypes,
-                        unsigned vectorSize) {
-      for (auto [tile, tileType, ptr, elemTy] :
-           llvm::zip(results, resultTypes, materializedResults,
-                     materializedResultElementTypes)) {
-        Location loc = tile.getLoc(); // or ptr?
-        auto b = TritonLLVMOpBuilder(loc, rewriter);
-        auto llvmStruct = cast<LLVM::LLVMStructType>(tileType);
-        Value llvmTile =
-            UnrealizedConversionCastOp::create(rewriter, loc, tileType, tile)
-                .getResult(0);
-        // TODO: should this be vector size or should we read the number of
-        // elements from the tile struct?
-        for (unsigned j = 0; j < vectorSize; ++j) {
-          Value elem = b.extract_val(llvmStruct.getBody()[j], llvmTile, j);
-          Value idx = b.add(flatOffset, b.i32_val(j));
-          Value gep = b.gep(ptr_ty(rewriter.getContext()), elemTy, ptr,
-                            ValueRange{idx});
-          b.store(elem, gep);
-        }
-      }
-    }
-
-    void updateIterArgs(ArrayRef<Value> newIterArgVals) {
-      assert(newIterArgVals.size() == loopIterArgs.size());
-      for (auto [i, newVal] : llvm::enumerate(newIterArgVals))
-        loopIterArgs[i] = newVal;
-    }
-
-    SmallVector<Value> getIterArgVals() const { return loopIterArgs; }
-
-    SmallVector<Value> getResults() const {
-      SmallVector<Value> ret(loopIterArgs.begin(), loopIterArgs.end());
-      ret.append(materializedResults.begin(), materializedResults.end());
-      return ret;
-    }
-
-  private:
-    SmallVector<ArgInfo> args;
-    SmallVector<Value> loopIterArgs;
-
-    SmallVector<Value> materializedResults;
-    SmallVector<Type> materializedResultElementTypes;
-
-    SmallVector<Value> tileOffsets;
-    Value flatOffset;
-  };
 
   SmallVector<ArgInfo>
   buildArgInfos(cpu::GenericOp op, OpAdaptor adaptor,
@@ -423,7 +436,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         remaining /= nc;
       }
 
-      helper.updateFlatOffset(rewriter, b.i32_val(vectorSize));
+      helper.incrementFlatOffset(rewriter, b.i32_val(vectorSize));
 
       // uses the tile offset state above
       SmallVector<Value> chunkedArgs =
@@ -591,7 +604,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           helper.addTileOffset(dimTileOffset);
 
           auto bb = TritonLLVMOpBuilder(loc, rewriter);
-          helper.updateFlatOffset(rewriter, bb.mul(loopI, innerStride));
+          helper.incrementFlatOffset(rewriter, bb.mul(loopI, innerStride));
           SmallVector<Value> innerIterArgVals(currentCarried.begin(),
                                               currentCarried.end());
 

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -394,7 +394,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     unsigned numIterArgs = op.getNumIterArgs();
     SmallVector<Value> newIterArgVals, tensorTiles;
 
-    // clone the body remapping operands. When handling the. yield, track tiles
+    // clone the body remapping operands. When handling the yield, track tiles
     // requiring materialization separately
     for (Operation &bOp : *body) {
       if (auto yieldOp = dyn_cast<cpu::YieldOp>(bOp)) {
@@ -433,7 +433,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     }
 
     for (unsigned i = 0; i < numChunks; ++i) {
-      SmallVector<Value> perDimOffsets(rank);
       unsigned remaining = i;
       LDBG("i = " << i);
       for (int d = rank - 1; d >= 0; --d) {
@@ -446,14 +445,10 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         remaining /= nc;
       }
 
-      helper.incrementFlatOffset(rewriter, b.i32_val(vectorSize));
-
       // uses the tile offset state above
       SmallVector<Value> chunkedArgs =
           helper.getLoopBodyBlockArgs(rewriter, vectorSize, i);
 
-      Value flatOffset = b.i32_val(i * vectorSize);
-      LDBG("flatOffset = " << (i * vectorSize));
       auto [newIterArgVals, loopTiles] =
           cloneTileBody(op, rewriter, chunkedArgs);
       helper.updateIterArgs(newIterArgVals);
@@ -462,6 +457,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
             return getTypeConverter()->convertType(tile.getType());
           });
       helper.scatterResults(rewriter, loopTiles, resultTypes, vectorSize);
+      helper.incrementFlatOffset(rewriter, b.i32_val(vectorSize));
     }
   }
 

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -147,6 +147,11 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
   struct ArgInfo {
     enum class Kind { IV, IterArg, Ins };
+
+    ArgInfo(Kind k) : kind(k) {}
+    ArgInfo(Kind k, Type tritonType, Type llvmType)
+        : kind(k), tritonType(tritonType), llvmType(llvmType) {}
+
     Kind kind;
     Type tritonType;
     Type llvmType;
@@ -154,6 +159,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     Value bufferPtr;       // only for global memory backed args
     unsigned numElems = 0; // only for global memory backed args
+    Value convertedArg; // only for non-alloca tensor args that need to be tiled
+                        // (unroll / static path)
 
     bool requiresMaterialization() const {
       return kind == Kind::Ins && isa<RankedTensorType>(tritonType) &&
@@ -203,21 +210,26 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     }
 
     void addTileOffset(Value offset) { tileOffsets.push_back(offset); }
+    void setTileOffset(unsigned dim, Value offset) {
+      tileOffsets[dim] = offset;
+    }
 
     void popTileOffset() { tileOffsets.pop_back(); }
 
+    // todo: rename incrementOffset?
     void updateFlatOffset(ConversionPatternRewriter &rewriter, Value inc) {
       auto b = TritonLLVMOpBuilder(flatOffset.getLoc(), rewriter);
       flatOffset = b.add(flatOffset, inc);
     }
 
-    SmallVector<Value> getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
-                                            unsigned vectorSize) {
+    SmallVector<Value>
+    getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
+                         unsigned vectorSize,
+                         std::optional<unsigned> loopIndex = std::nullopt) {
       // start with IVs
       SmallVector<Value> blockArgs = {tileOffsets.begin(), tileOffsets.end()};
 
-      // Add iter args -- TODO: remove from function arg and hold this state in
-      // the class
+      // iter args
       blockArgs.append(loopIterArgs.begin(), loopIterArgs.end());
 
       // Add ins args
@@ -225,16 +237,45 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         if (argInfo.kind == ArgInfo::Kind::Ins) {
           Location loc = argInfo.operand.getLoc();
 
+          // if we are in the static (unrolled) path, we need to handle
+          // non-alloca tensor args by extracting the appropriate chunk for this
+          // iteration.
+          if (loopIndex.has_value()) {
+            auto tensorTy = dyn_cast<RankedTensorType>(argInfo.tritonType);
+            if (tensorTy && !argInfo.bufferPtr) {
+              assert(argInfo.convertedArg && "expected adaptor-converted arg "
+                                             "for non-alloca tensor operand");
+              auto tileStructTy = cast<LLVM::LLVMStructType>(argInfo.llvmType);
+              Value tile = LLVM::UndefOp::create(rewriter, loc, tileStructTy);
+              TritonLLVMOpBuilder b(argInfo.operand.getLoc(), rewriter);
+
+              for (unsigned j = 0; j < vectorSize; ++j) {
+                int64_t srcIndex = loopIndex.value() * vectorSize + j;
+                LDBG("Read " << srcIndex);
+                Value extractedElement = b.extract_val(
+                    tileStructTy.getBody()[j], argInfo.convertedArg, srcIndex);
+                tile = b.insert_val(tileStructTy, tile, extractedElement, j);
+              }
+
+              Value castedTile = UnrealizedConversionCastOp::create(
+                                     rewriter, loc, argInfo.tritonType, tile)
+                                     .getResult(0);
+              blockArgs.push_back(castedTile);
+              continue;
+            }
+          }
+
           if (argInfo.bufferPtr) {
             // load this tiles elements from the global buffer
             auto tileStructTy = cast<LLVM::LLVMStructType>(argInfo.llvmType);
             Type elemTy = tileStructTy.getBody()[0];
             Value tileStruct =
                 LLVM::UndefOp::create(rewriter, loc, tileStructTy);
-            // TODO: should this be vectorSize?
             auto b = TritonLLVMOpBuilder(loc, rewriter);
 
+            // TODO: should this be vectorSize?
             for (unsigned j = 0; j < vectorSize; ++j) {
+              // TODO: use builder
               Value globalIdx =
                   LLVM::AddOp::create(rewriter, loc, flatOffset, b.i32_val(j));
               Value gep = LLVM::GEPOp::create(
@@ -334,8 +375,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     // handle loop induction vars first
     for (unsigned i = 0; i < tileShape.size(); i++) {
-      args.emplace_back(
-          ArgInfo{ArgInfo::Kind::IV, nullptr, i32_ty, Value(), 0});
+      args.emplace_back(ArgInfo(ArgInfo::Kind::IV, nullptr, i32_ty));
     }
 
     for (unsigned i = 0; i < op.getNumIterArgs(); i++) {
@@ -346,8 +386,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
       // TODO: create alloca backed buffers corresponding to init arg and copy
       // init arg in if we have a tensor type.
-      args.emplace_back(
-          ArgInfo{ArgInfo::Kind::IterArg, tritonType, llvmType, Value(), 0});
+      args.emplace_back(ArgInfo(ArgInfo::Kind::IterArg, tritonType, llvmType));
     }
 
     Block *body = &op.getBody().front();
@@ -356,8 +395,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     for (auto [i, origArg, llvmArg] :
          llvm::enumerate(body->getArguments().drop_front(op.getInsArgOffset()),
                          adaptor.getIns())) {
-      ArgInfo argInfo;
-      argInfo.kind = ArgInfo::Kind::Ins;
+      ArgInfo argInfo(ArgInfo::Kind::Ins);
 
       argInfo.tritonType = origArg.getType();
       argInfo.operand = op.getIns()[i];
@@ -373,6 +411,12 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         argInfo.llvmType = getTypeConverter()->convertType(origArg.getType());
       } else {
         argInfo.llvmType = llvmArg.getType();
+        if (isa<RankedTensorType>(argInfo.tritonType)) {
+          // tensor arguments that aren't backed by an alloca need to store the
+          // adaptor value so they can be sliced when inputs to the cloned loop
+          // body are created during unrolling
+          argInfo.convertedArg = adaptor.getIns()[i];
+        }
       }
       args.push_back(argInfo);
     }
@@ -384,14 +428,20 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
   // iterArgVals provides the current accumulator values for iter args.
   std::pair<SmallVector<Value>, SmallVector<Value>>
   cloneTileBody(cpu::GenericOp op, ConversionPatternRewriter &rewriter,
-                ArrayRef<Value> iterArgVals, ArrayRef<Value> chunkedArgs,
-                ArrayRef<Value> tileOffsets) const {
+                ArrayRef<Value> chunkedArgs) const {
     assert(op.getBody().getBlocks().size() == 1 &&
            "expected generic op body to have one block");
     Block *body = &op.getBody().front();
 
     IRMapping mapping;
-    // IVs
+#if 1
+    for (auto [bodyArg, newArg] :
+         llvm::zip(body->getArguments(), chunkedArgs)) {
+      mapping.map(bodyArg, newArg);
+    }
+#else
+    // TODO: we should be able to handle all this in build args and just map
+    // body arguments -> args (making sure hte sizes match) IVs
     for (auto [blockArg, offset] : llvm::zip(
              body->getArguments().take_front(tileOffsets.size()), tileOffsets))
       mapping.map(blockArg, offset);
@@ -403,7 +453,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
          llvm::zip(body->getArguments().drop_front(op.getInsArgOffset()),
                    chunkedArgs))
       mapping.map(bodyArg, chunkedArg);
-
+#endif
     unsigned numIterArgs = op.getNumIterArgs();
     SmallVector<Value> newIterArgVals, tensorTiles;
 
@@ -451,7 +501,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
   // llvm.extractvalue (which requires compile-time indices), or when there is
   // only one tile and loop overhead is unnecessary.
   // iterArgVals is updated in-place to the final accumulated values.
-  void emitUnrolled(cpu::GenericOp op, OpAdaptor adaptor,
+  void emitUnrolled(cpu::GenericOp op, LoopHelper &helper,
                     ConversionPatternRewriter &rewriter, unsigned numChunks,
                     unsigned vectorSize, ArrayRef<int32_t> blockShape,
                     ArrayRef<int32_t> tileShape,
@@ -464,11 +514,20 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     LDBG("Unrolling generic, cloning body for " << numChunks
                                                 << " loop iterations");
 
+    // initialize tile offsets inside the helper
+    unsigned rank = blockShape.size();
+    for (int d = rank - 1; d >= 0; --d) {
+      helper.addTileOffset(Value());
+    }
+
     for (unsigned i = 0; i < numChunks; ++i) {
+#if 1
+
+#else
       SmallVector<Value> chunkedArgs =
           buildStaticChunkedArgs(op, adaptor, rewriter, i, vectorSize);
+#endif
 
-      unsigned rank = blockShape.size();
       SmallVector<Value> perDimOffsets(rank);
       unsigned remaining = i;
       LDBG("i = " << i);
@@ -478,14 +537,19 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         LDBG("perDimOffsets[" << d << "] = " << chunkIdx << " * "
                               << tileShape[d] << " = "
                               << (chunkIdx * tileShape[d]));
-        perDimOffsets[d] = b.i32_val(chunkIdx * tileShape[d]);
+        helper.setTileOffset(d, b.i32_val(chunkIdx * tileShape[d]));
         remaining /= nc;
       }
 
+      helper.updateFlatOffset(rewriter, b.i32_val(vectorSize));
+
+      // uses the tile offset state above
+      SmallVector<Value> chunkedArgs =
+          helper.getLoopBodyBlockArgs(rewriter, vectorSize, i);
+
       Value flatOffset = b.i32_val(i * vectorSize);
       LDBG("flatOffset = " << (i * vectorSize));
-      auto [newIterArgVals, tiles] =
-          cloneTileBody(op, rewriter, iterArgVals, chunkedArgs, perDimOffsets);
+      auto [newIterArgVals, tiles] = cloneTileBody(op, rewriter, chunkedArgs);
       iterArgVals.assign(newIterArgVals.begin(), newIterArgVals.end());
       scatterTiles(rewriter, loc, tiles, flatOffset, vectorSize, tensorAccPtrs,
                    tensorElemTys);
@@ -733,9 +797,10 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       assert(blockShape.size() == tileShape.size() &&
              "expected blockShape and tileShape to have "
              "the same rank");
-      LoopHelper helper(argInfos, iterArgVals, /*flatOffset=*/nullptr, op,
+      auto b = TritonLLVMOpBuilder(loc, rewriter);
+      LoopHelper helper(argInfos, iterArgVals, /*flatOffset=*/b.i32_val(0), op,
                         getTypeConverter(), rewriter);
-      emitUnrolled(op, adaptor, rewriter, numChunks, vectorSize, blockShape,
+      emitUnrolled(op, helper, rewriter, numChunks, vectorSize, blockShape,
                    tileShape, iterArgVals, helper.getTensorAccPtrs(),
                    helper.getTensorElemTys());
       results = helper.getResults();

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -563,7 +563,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
   // Emits nested loops over tiles, threading iter arg values as loop-carried
   // state.
-  void emitNestedLoops(cpu::GenericOp op, OpAdaptor adaptor, LoopHelper &helper,
+  void emitNestedLoops(cpu::GenericOp op, LoopHelper &helper,
                        ConversionPatternRewriter &rewriter, unsigned dim,
                        ArrayRef<Value> blockShape, ArrayRef<int32_t> tileShape,
                        unsigned vectorSize,
@@ -639,14 +639,16 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         [&](Value loopI, Value dimTileOffset, ArrayRef<Value> currentCarried,
             Block *afterBlock) -> SmallVector<Value> {
           helper.addTileOffset(dimTileOffset);
-          // TODO: use builder?
-          helper.updateFlatOffset(
-              rewriter, LLVM::MulOp::create(rewriter, loc, loopI, innerStride));
+
+          auto bb = TritonLLVMOpBuilder(loc, rewriter);
+          helper.updateFlatOffset(rewriter, bb.mul(loopI, innerStride));
           SmallVector<Value> innerIterArgVals(currentCarried.begin(),
                                               currentCarried.end());
+
           helper.updateIterArgs(innerIterArgVals);
-          emitNestedLoops(op, adaptor, helper, rewriter, dim + 1, blockShape,
-                          tileShape, vectorSize, afterBlock);
+          emitNestedLoops(op, helper, rewriter, dim + 1, blockShape, tileShape,
+                          vectorSize, afterBlock);
+
           helper.popTileOffset();
           return helper.getIterArgVals();
         });
@@ -756,7 +758,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                         getTypeConverter(), rewriter);
       SmallVector<Value> blockShapeVals(op.getBlockShape().begin(),
                                         op.getBlockShape().end());
-      emitNestedLoops(op, adaptor, helper, rewriter, /*dim=*/0, blockShapeVals,
+      emitNestedLoops(op, helper, rewriter, /*dim=*/0, blockShapeVals,
                       tileShape, vectorSize);
       results = helper.getResults();
     }

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -112,6 +112,106 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     return chunkedArgs;
   }
 
+  struct ArgInfo {
+    enum class Kind { IV, IterArg, Ins };
+    Kind kind;
+    Type tritonType;
+    Type llvmType;
+
+    Value bufferPtr;       // only for global memory backed args
+    unsigned numElems = 0; // only for global memory backed args
+
+    bool requiresMaterialization() const {
+      return kind == Kind::Ins && isa<RankedTensorType>(tritonType) &&
+             !bufferPtr;
+    }
+  };
+
+  class LoopHelper {
+  public:
+    LoopHelper(ArrayRef<ArgInfo> args, ArrayRef<Value> loopIterArgs,
+               Value flatOffset)
+        : args(args.begin(), args.end()),
+          loopIterArgs(loopIterArgs.begin(), loopIterArgs.end()),
+          flatOffset(flatOffset) {}
+
+    SmallVector<Value> getEntryArgs() {
+      return {tileOffsets.begin(), tileOffsets.end()};
+    }
+
+    void addTileOffset(Value offset) { tileOffsets.push_back(offset); }
+
+    void popTileOffset() { tileOffsets.pop_back(); }
+
+    void updateFlatOffset(ConversionPatternRewriter &rewriter, Value inc) {
+      auto b = TritonLLVMOpBuilder(flatOffset.getLoc(), rewriter);
+      flatOffset = b.add(flatOffset, inc);
+    }
+
+    // TODO: delete me
+    Value getFlatOffset() const { return flatOffset; }
+
+  private:
+    SmallVector<ArgInfo> args;
+    SmallVector<Value> loopIterArgs;
+    SmallVector<Value> materializedResults;
+    SmallVector<Value> tileOffsets;
+    Value flatOffset;
+  };
+
+  SmallVector<ArgInfo>
+  buildArgInfos(cpu::GenericOp op, OpAdaptor adaptor,
+                ArrayRef<int32_t> tileShape,
+                ConversionPatternRewriter &rewriter) const {
+    SmallVector<ArgInfo> args;
+
+    // handle loop induction vars first
+    for (unsigned i = 0; i < tileShape.size(); i++) {
+      args.emplace_back(
+          ArgInfo{ArgInfo::Kind::IV, nullptr, i32_ty, Value(), 0});
+    }
+
+    for (unsigned i = 0; i < op.getNumIterArgs(); i++) {
+      Type tritonType = op.getIterArg(i).getType();
+      assert(!isa<RankedTensorType>(tritonType) &&
+             "tensor type iter args not yet supported");
+      Type llvmType = getTypeConverter()->convertType(tritonType);
+
+      // TODO: create alloca backed buffers corresponding to init arg and copy
+      // init arg in if we have a tensor type.
+      args.emplace_back(
+          ArgInfo{ArgInfo::Kind::IterArg, tritonType, llvmType, Value(), 0});
+    }
+
+    Block *body = &op.getBody().front();
+    const auto &ins = op.getIns();
+
+    for (auto [i, origArg, llvmArg] :
+         llvm::enumerate(body->getArguments().drop_front(op.getInsArgOffset()),
+                         adaptor.getIns())) {
+      ArgInfo argInfo;
+      argInfo.kind = ArgInfo::Kind::Ins;
+
+      argInfo.tritonType = origArg.getType();
+      Value ptrArg = getGenericOutputTensorAsPtr(op, i, llvmArg);
+      if (ptrArg) {
+        auto allocationTensorTy = cast<RankedTensorType>(ins[i].getType());
+        int64_t numElems =
+            std::accumulate(allocationTensorTy.getShape().begin(),
+                            allocationTensorTy.getShape().end(), int64_t{1},
+                            std::multiplies<>());
+        argInfo.bufferPtr = ptrArg;
+        argInfo.numElems = numElems;
+        argInfo.llvmType = getTypeConverter()->convertType(origArg.getType());
+      } else {
+        argInfo.llvmType = llvmArg.getType();
+      }
+      args.push_back(argInfo);
+    }
+
+    return args;
+  }
+
   // Returns {newIterArgVals, tensorTiles} from the tile's ttc.yield.
   // iterArgVals provides the current accumulator values for iter args.
   std::pair<SmallVector<Value>, SmallVector<Value>>
@@ -353,9 +453,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
   // Emits nested loops over tiles, threading iter arg values as loop-carried
   // state. iterArgVals is updated in-place to the final accumulated values.
-  void emitNestedLoops(cpu::GenericOp op, OpAdaptor adaptor,
+  void emitNestedLoops(cpu::GenericOp op, OpAdaptor adaptor, LoopHelper &helper,
                        ConversionPatternRewriter &rewriter, unsigned dim,
-                       SmallVectorImpl<Value> &accOffsets, Value flatElemOffset,
                        ArrayRef<Value> blockShape, ArrayRef<int32_t> tileShape,
                        unsigned vectorSize, SmallVectorImpl<Value> &iterArgVals,
                        ArrayRef<Value> tensorAccPtrs,
@@ -375,8 +474,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       Block *bodyEntry = &bodyRegion.front();
 
       // build tile args before inlining (references block arguments)
-      auto tileArgs = buildDynamicChunkedArgs(op, adaptor, rewriter,
-                                              flatElemOffset, vectorSize);
+      auto tileArgs = buildDynamicChunkedArgs(
+          op, adaptor, rewriter, helper.getFlatOffset(), vectorSize);
 
       rewriter.inlineRegionBefore(bodyRegion, *innerAfterBlock->getParent(),
                                   innerAfterBlock->getIterator());
@@ -388,7 +487,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                                                     getTypeConverter());
 
       // entryArgs: [IVs..., iterArgs..., insArgs...]
-      SmallVector<Value> entryArgs(accOffsets.begin(), accOffsets.end());
+      SmallVector<Value> entryArgs = helper.getEntryArgs();
       for (auto arg : iterArgVals)
         LDBG("iterArgVals: " << arg);
       entryArgs.append(iterArgVals.begin(), iterArgVals.end());
@@ -413,8 +512,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         // scatter non-iter-arg tensor tiles
         SmallVector<Value> loopTiles(yieldOp.getValues().begin() + numIterArgs,
                                      yieldOp.getValues().end());
-        scatterTiles(rewriter, loc, loopTiles, flatElemOffset, vectorSize,
-                     tensorAccPtrs, tensorElemTys);
+        scatterTiles(rewriter, loc, loopTiles, helper.getFlatOffset(),
+                     vectorSize, tensorAccPtrs, tensorElemTys);
 
         rewriter.eraseOp(yieldOp);
         rewriter.setInsertionPointToEnd(&block);
@@ -436,84 +535,20 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         rewriter, loc, numChunks, tileShape[dim], iterArgVals,
         [&](Value loopI, Value dimTileOffset, ArrayRef<Value> currentCarried,
             Block *afterBlock) -> SmallVector<Value> {
-          accOffsets.push_back(dimTileOffset);
+          helper.addTileOffset(dimTileOffset);
           // TODO: use builder?
-          Value newFlat = LLVM::AddOp::create(
-              rewriter, loc, flatElemOffset,
-              LLVM::MulOp::create(rewriter, loc, loopI, innerStride));
+          helper.updateFlatOffset(
+              rewriter, LLVM::MulOp::create(rewriter, loc, loopI, innerStride));
           SmallVector<Value> innerIterArgVals(currentCarried.begin(),
                                               currentCarried.end());
-          emitNestedLoops(op, adaptor, rewriter, dim + 1, accOffsets, newFlat,
-                          blockShape, tileShape, vectorSize, innerIterArgVals,
+          emitNestedLoops(op, adaptor, helper, rewriter, dim + 1, blockShape,
+                          tileShape, vectorSize, innerIterArgVals,
                           tensorAccPtrs, tensorElemTys, afterBlock);
-          accOffsets.pop_back();
+          helper.popTileOffset();
           return innerIterArgVals;
         });
 
     iterArgVals.assign(finalCarried.begin(), finalCarried.end());
-  }
-
-  struct ArgInfo {
-    enum class Kind { IV, IterArg, Ins };
-    Kind kind;
-    Type tritonType;
-    Type llvmType;
-
-    Value bufferPtr;       // only for global memory backed args
-    unsigned numElems = 0; // only for global memory backed args
-  };
-
-  SmallVector<ArgInfo>
-  buildArgInfos(cpu::GenericOp op, OpAdaptor adaptor,
-                ArrayRef<int32_t> tileShape,
-                ConversionPatternRewriter &rewriter) const {
-    SmallVector<ArgInfo> args;
-
-    // handle loop induction vars first
-    for (unsigned i = 0; i < tileShape.size(); i++) {
-      args.emplace_back(
-          ArgInfo{ArgInfo::Kind::IV, nullptr, i32_ty, Value(), 0});
-    }
-
-    for (unsigned i = 0; i < op.getNumIterArgs(); i++) {
-      Type tritonType = op.getIterArg(i).getType();
-      assert(!isa<RankedTensorType>(tritonType) &&
-             "tensor type iter args not yet supported");
-      Type llvmType = getTypeConverter()->convertType(tritonType);
-
-      // TODO: create alloca backed buffers corresponding to init arg and copy
-      // init arg in if we have a tensor type.
-      args.emplace_back(
-          ArgInfo{ArgInfo::Kind::IterArg, tritonType, llvmType, Value(), 0});
-    }
-
-    Block *body = &op.getBody().front();
-    const auto &ins = op.getIns();
-
-    for (auto [i, origArg, llvmArg] :
-         llvm::enumerate(body->getArguments().drop_front(op.getInsArgOffset()),
-                         adaptor.getIns())) {
-      ArgInfo argInfo;
-      argInfo.kind = ArgInfo::Kind::Ins;
-
-      argInfo.tritonType = origArg.getType();
-      Value ptrArg = getGenericOutputTensorAsPtr(op, i, llvmArg);
-      if (ptrArg) {
-        auto allocationTensorTy = cast<RankedTensorType>(ins[i].getType());
-        int64_t numElems =
-            std::accumulate(allocationTensorTy.getShape().begin(),
-                            allocationTensorTy.getShape().end(), int64_t{1},
-                            std::multiplies<>());
-        argInfo.bufferPtr = ptrArg;
-        argInfo.numElems = numElems;
-        argInfo.llvmType = getTypeConverter()->convertType(origArg.getType());
-      } else {
-        argInfo.llvmType = llvmArg.getType();
-      }
-      args.push_back(argInfo);
-    }
-
-    return args;
   }
 
   LogicalResult
@@ -609,18 +644,9 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     // (llvm.extractvalue only accepts attribute indices). Alloca-backed tensors
     // from a prior generic are GEP-indexed and support dynamic offsets.
     const bool requiresTensorArgMaterialization =
-        llvm::any_of(llvm::enumerate(llvm::zip(
-                         body->getArguments().drop_front(op.getInsArgOffset()),
-                         adaptor.getIns())),
-                     [this, &op](auto pair) {
-                       auto [opIdx, argPair] = pair;
-                       auto [origArg, llvmArg] = argPair;
-                       if (!isa<RankedTensorType>(origArg.getType()))
-                         return false;
-                       if (getGenericOutputTensorAsPtr(op, opIdx, llvmArg))
-                         return false;
-                       return true;
-                     });
+        llvm::any_of(argInfos, [](const ArgInfo &argInfo) {
+          return argInfo.requiresMaterialization();
+        });
 
     // Iter arg values start from init_vals and are updated tile-by-tile.
     SmallVector<Value> iterArgVals(adaptor.getInitVals().begin(),
@@ -669,13 +695,14 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
               : true;
       assert(allUsersAreGeneric && "expected all generic op users to also be "
                                    "generic ops on dynamic path");
-      SmallVector<Value> accOffsets;
+
       auto b = TritonLLVMOpBuilder(loc, rewriter);
+      LoopHelper helper(argInfos, iterArgVals, /*flatOffset=*/b.i32_val(0));
       SmallVector<Value> blockShapeVals(op.getBlockShape().begin(),
                                         op.getBlockShape().end());
-      emitNestedLoops(op, adaptor, rewriter, /*dim=*/0, accOffsets,
-                      b.i32_val(0), blockShapeVals, tileShape, vectorSize,
-                      iterArgVals, tensorAccPtrs, tensorElemTys);
+      emitNestedLoops(op, adaptor, helper, rewriter, /*dim=*/0, blockShapeVals,
+                      tileShape, vectorSize, iterArgVals, tensorAccPtrs,
+                      tensorElemTys);
     }
 
     // Collect all replacement values atomically. Mixing replaceAllUsesWith +

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -453,6 +453,69 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     iterArgVals.assign(finalCarried.begin(), finalCarried.end());
   }
 
+  struct ArgInfo {
+    enum class Kind { IV, IterArg, Ins };
+    Kind kind;
+    Type tritonType;
+    Type llvmType;
+
+    Value bufferPtr;       // only for global memory backed args
+    unsigned numElems = 0; // only for global memory backed args
+  };
+
+  SmallVector<ArgInfo>
+  buildArgInfos(cpu::GenericOp op, OpAdaptor adaptor,
+                ArrayRef<int32_t> tileShape,
+                ConversionPatternRewriter &rewriter) const {
+    SmallVector<ArgInfo> args;
+
+    // handle loop induction vars first
+    for (unsigned i = 0; i < tileShape.size(); i++) {
+      args.emplace_back(
+          ArgInfo{ArgInfo::Kind::IV, nullptr, i32_ty, Value(), 0});
+    }
+
+    for (unsigned i = 0; i < op.getNumIterArgs(); i++) {
+      Type tritonType = op.getIterArg(i).getType();
+      assert(!isa<RankedTensorType>(tritonType) &&
+             "tensor type iter args not yet supported");
+      Type llvmType = getTypeConverter()->convertType(tritonType);
+
+      // TODO: create alloca backed buffers corresponding to init arg and copy
+      // init arg in if we have a tensor type.
+      args.emplace_back(
+          ArgInfo{ArgInfo::Kind::IterArg, tritonType, llvmType, Value(), 0});
+    }
+
+    Block *body = &op.getBody().front();
+    const auto &ins = op.getIns();
+
+    for (auto [i, origArg, llvmArg] :
+         llvm::enumerate(body->getArguments().drop_front(op.getInsArgOffset()),
+                         adaptor.getIns())) {
+      ArgInfo argInfo;
+      argInfo.kind = ArgInfo::Kind::Ins;
+
+      argInfo.tritonType = origArg.getType();
+      Value ptrArg = getGenericOutputTensorAsPtr(op, i, llvmArg);
+      if (ptrArg) {
+        auto allocationTensorTy = cast<RankedTensorType>(ins[i].getType());
+        int64_t numElems =
+            std::accumulate(allocationTensorTy.getShape().begin(),
+                            allocationTensorTy.getShape().end(), int64_t{1},
+                            std::multiplies<>());
+        argInfo.bufferPtr = ptrArg;
+        argInfo.numElems = numElems;
+        argInfo.llvmType = getTypeConverter()->convertType(origArg.getType());
+      } else {
+        argInfo.llvmType = llvmArg.getType();
+      }
+      args.push_back(argInfo);
+    }
+
+    return args;
+  }
+
   LogicalResult
   matchAndRewrite(cpu::GenericOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -477,6 +540,16 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     op->print(os, OpPrintingFlags().skipRegions());
     LDBG("Lowering generic op: " << s
                                  << "\n  with vectorSize = " << vectorSize);
+
+    SmallVector<ArgInfo> argInfos =
+        buildArgInfos(op, adaptor, tileShape, rewriter);
+    for (auto argInfo : argInfos) {
+      LDBG("ArgInfo: kind = " << static_cast<int>(argInfo.kind)
+                              << ", tritonType = " << argInfo.tritonType
+                              << ", llvmType = " << argInfo.llvmType
+                              << ", bufferPtr = " << argInfo.bufferPtr
+                              << ", numElems = " << argInfo.numElems);
+    }
 
     // Tensor results are materialized as thread-local global arrays rather than
     // LLVM vectors. This avoids loop-carried <blockSize x elemTy> phi nodes

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -211,16 +211,14 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       flatOffset = b.add(flatOffset, inc);
     }
 
-    SmallVector<Value>
-    getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
-                         unsigned vectorSize,
-                         SmallVectorImpl<Value> &iterArgVals) {
+    SmallVector<Value> getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
+                                            unsigned vectorSize) {
       // start with IVs
       SmallVector<Value> blockArgs = {tileOffsets.begin(), tileOffsets.end()};
 
       // Add iter args -- TODO: remove from function arg and hold this state in
       // the class
-      blockArgs.append(iterArgVals.begin(), iterArgVals.end());
+      blockArgs.append(loopIterArgs.begin(), loopIterArgs.end());
 
       // Add ins args
       for (const auto &argInfo : args) {
@@ -295,6 +293,20 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           b.store(elem, gep);
         }
       }
+    }
+
+    void updateIterArgs(ArrayRef<Value> newIterArgVals) {
+      assert(newIterArgVals.size() == loopIterArgs.size());
+      for (auto [i, newVal] : llvm::enumerate(newIterArgVals))
+        loopIterArgs[i] = newVal;
+    }
+
+    SmallVector<Value> getIterArgVals() const { return loopIterArgs; }
+
+    SmallVector<Value> getResults() const {
+      SmallVector<Value> ret(loopIterArgs.begin(), loopIterArgs.end());
+      ret.append(materializedResults.begin(), materializedResults.end());
+      return ret;
     }
 
     // TODO: delete me
@@ -531,6 +543,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     // loop body: emit tile, increment counter, branch back with new carried
     rewriter.setInsertionPointToEnd(loopBody);
     Value tileOffset = b.mul(loopI, b.i32_val(tileSize));
+
     SmallVector<Value> newCarried =
         bodyFn(loopI, tileOffset, currentCarried, afterBlock);
 
@@ -544,15 +557,16 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     SmallVector<Value> finalCarried;
     for (unsigned i = 0; i < carriedTys.size(); ++i)
       finalCarried.push_back(afterBlock->getArgument(i));
+
     return finalCarried;
   }
 
   // Emits nested loops over tiles, threading iter arg values as loop-carried
-  // state. iterArgVals is updated in-place to the final accumulated values.
+  // state.
   void emitNestedLoops(cpu::GenericOp op, OpAdaptor adaptor, LoopHelper &helper,
                        ConversionPatternRewriter &rewriter, unsigned dim,
                        ArrayRef<Value> blockShape, ArrayRef<int32_t> tileShape,
-                       unsigned vectorSize, SmallVectorImpl<Value> &iterArgVals,
+                       unsigned vectorSize,
                        Block *innerAfterBlock = nullptr) const {
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -568,8 +582,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       Block *bodyEntry = &bodyRegion.front();
 
       // build tile args before inlining (references block arguments)
-      auto entryArgs =
-          helper.getLoopBodyBlockArgs(rewriter, vectorSize, iterArgVals);
+      auto entryArgs = helper.getLoopBodyBlockArgs(rewriter, vectorSize);
 
       rewriter.inlineRegionBefore(bodyRegion, *innerAfterBlock->getParent(),
                                   innerAfterBlock->getIterator());
@@ -591,9 +604,10 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
         rewriter.setInsertionPoint(yieldOp);
         // extract new iter arg values from the leading yield operands
-        iterArgVals.clear();
-        for (unsigned i = 0; i < numIterArgs; ++i)
-          iterArgVals.push_back(yieldOp.getValues()[i]);
+        SmallVector<Value> newIterArgVals(yieldOp.getValues().begin(),
+                                          yieldOp.getValues().begin() +
+                                              numIterArgs);
+        helper.updateIterArgs(newIterArgVals);
 
         // scatter non-iter-arg tensor tiles
         SmallVector<Value> loopTiles(yieldOp.getValues().begin() + numIterArgs,
@@ -603,7 +617,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
               return getTypeConverter()->convertType(tile.getType());
             });
         helper.scatterResults(rewriter, loopTiles, resultTypes, vectorSize);
-
 
         rewriter.eraseOp(yieldOp);
         rewriter.setInsertionPointToEnd(&block);
@@ -622,7 +635,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           b.mul(innerStride, b.sdiv(blockShape[d], b.i32_val(tileShape[d])));
 
     auto finalCarried = emitSingleLoop(
-        rewriter, loc, numChunks, tileShape[dim], iterArgVals,
+        rewriter, loc, numChunks, tileShape[dim], helper.getIterArgVals(),
         [&](Value loopI, Value dimTileOffset, ArrayRef<Value> currentCarried,
             Block *afterBlock) -> SmallVector<Value> {
           helper.addTileOffset(dimTileOffset);
@@ -631,13 +644,14 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
               rewriter, LLVM::MulOp::create(rewriter, loc, loopI, innerStride));
           SmallVector<Value> innerIterArgVals(currentCarried.begin(),
                                               currentCarried.end());
+          helper.updateIterArgs(innerIterArgVals);
           emitNestedLoops(op, adaptor, helper, rewriter, dim + 1, blockShape,
-                          tileShape, vectorSize, innerIterArgVals, afterBlock);
+                          tileShape, vectorSize, afterBlock);
           helper.popTileOffset();
-          return innerIterArgVals;
+          return helper.getIterArgVals();
         });
 
-    iterArgVals.assign(finalCarried.begin(), finalCarried.end());
+    helper.updateIterArgs(finalCarried);
   }
 
   LogicalResult
@@ -710,7 +724,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       return failure();
     }
 
-    SmallVector<Value> materializedTensorResults;
+    SmallVector<Value> results;
     if (requiresTensorArgMaterialization || numChunks == 1) {
       assert(numChunks > 0 && "expected numChunks to be positive when required "
                               "or statically computable");
@@ -722,8 +736,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       emitUnrolled(op, adaptor, rewriter, numChunks, vectorSize, blockShape,
                    tileShape, iterArgVals, helper.getTensorAccPtrs(),
                    helper.getTensorElemTys());
-      materializedTensorResults.append(helper.getTensorAccPtrs().begin(),
-                                       helper.getTensorAccPtrs().end());
+      results = helper.getResults();
     } else {
       const bool genericHasTensorOutputs =
           llvm::any_of(op->getResults(), [](Value result) {
@@ -744,18 +757,14 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       SmallVector<Value> blockShapeVals(op.getBlockShape().begin(),
                                         op.getBlockShape().end());
       emitNestedLoops(op, adaptor, helper, rewriter, /*dim=*/0, blockShapeVals,
-                      tileShape, vectorSize, iterArgVals);
-      materializedTensorResults.append(helper.getTensorAccPtrs().begin(),
-                                       helper.getTensorAccPtrs().end());
+                      tileShape, vectorSize);
+      results = helper.getResults();
     }
 
-    SmallVector<Value> allReplacements(iterArgVals.begin(), iterArgVals.end());
-    allReplacements.append(materializedTensorResults.begin(),
-                           materializedTensorResults.end());
-    if (allReplacements.empty())
+    if (results.empty())
       rewriter.eraseOp(op);
     else
-      rewriter.replaceOp(op, allReplacements);
+      rewriter.replaceOp(op, results);
     return success();
   }
 };

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -163,9 +163,10 @@ LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, ArrayRef<Value> loopIterArgs,
   }
 }
 
-SmallVector<Value> LoopHelper::getLoopBodyBlockArgs(
-    ConversionPatternRewriter &rewriter, unsigned vectorSize,
-    std::optional<unsigned> loopIndex) {
+SmallVector<Value>
+LoopHelper::getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
+                                 unsigned vectorSize,
+                                 std::optional<unsigned> loopIndex) {
   // start with IVs
   SmallVector<Value> blockArgs = {tileOffsets.begin(), tileOffsets.end()};
 
@@ -214,15 +215,11 @@ SmallVector<Value> LoopHelper::getLoopBodyBlockArgs(
 
         // TODO: should this be vectorSize?
         for (unsigned j = 0; j < vectorSize; ++j) {
-          // TODO: use builder
-          Value globalIdx =
-              LLVM::AddOp::create(rewriter, loc, flatOffset, b.i32_val(j));
-          Value gep = LLVM::GEPOp::create(
-              rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext()),
-              elemTy, argInfo.bufferPtr, ValueRange{globalIdx});
-          Value elem = LLVM::LoadOp::create(rewriter, loc, elemTy, gep);
-          tileStruct =
-              LLVM::InsertValueOp::create(rewriter, loc, tileStruct, elem, {j});
+          Value globalIdx = b.add(flatOffset, b.i32_val(j));
+          Value gep = b.gep(LLVM::LLVMPointerType::get(rewriter.getContext()),
+                            elemTy, argInfo.bufferPtr, ValueRange{globalIdx});
+          Value elem = b.load(elemTy, gep);
+          tileStruct = b.insert_val(tileStructTy, tileStruct, elem, j);
         }
         blockArgs.push_back(tileStruct);
       } else if (isa<PointerType>(argInfo.tritonType)) {

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -66,7 +66,20 @@ struct ArgInfo {
   bool requiresMaterialization() const {
     return kind == Kind::Ins && isa<RankedTensorType>(tritonType) && !bufferPtr;
   }
+
+  void print(llvm::raw_ostream &os) const {
+    static constexpr StringRef kindNames[] = {"IV", "IterArg", "Ins"};
+    os << "ArgInfo{kind=" << kindNames[static_cast<int>(kind)]
+       << ", tritonType=" << tritonType << ", llvmType=" << llvmType
+       << ", operand=" << operand << ", bufferPtr=" << bufferPtr
+       << ", numElems=" << numElems << ", convertedArg=" << convertedArg << "}";
+  }
 };
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const ArgInfo &a) {
+  a.print(os);
+  return os;
+}
 
 class LoopHelper {
 public:
@@ -643,13 +656,14 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     SmallVector<ArgInfo> argInfos =
         buildArgInfos(op, adaptor, tileShape, rewriter);
-    for (auto argInfo : argInfos) {
-      LDBG("ArgInfo: kind = " << static_cast<int>(argInfo.kind)
-                              << ", tritonType = " << argInfo.tritonType
-                              << ", llvmType = " << argInfo.llvmType
-                              << ", bufferPtr = " << argInfo.bufferPtr
-                              << ", numElems = " << argInfo.numElems);
-    }
+
+    LLVM_DEBUG({
+      for (auto [i, argInfo] : llvm::enumerate(argInfos)) {
+        DBGS() << "Arg " << i << ": ";
+        argInfo.print(llvm::dbgs());
+        DBGS() << "\n";
+      }
+    });
 
     // Tensor args passed as LLVM structs require static tile indices
     // (llvm.extractvalue only accepts attribute indices). Alloca-backed tensors

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -80,71 +80,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     return castOp.getInputs()[0];
   }
 
-  SmallVector<Value> buildStaticChunkedArgs(cpu::GenericOp op,
-                                            OpAdaptor adaptor,
-                                            ConversionPatternRewriter &rewriter,
-                                            unsigned i,
-                                            unsigned vectorSize) const {
-    Location loc = op.getLoc();
-    Block *body = &op.getBody().front();
-    SmallVector<Value> chunkedArgs;
-
-    for (auto [opIdx, origArg, llvmArg] :
-         llvm::enumerate(body->getArguments().drop_front(op.getInsArgOffset()),
-                         adaptor.getIns())) {
-      LDBG("Chunk operand " << opIdx << " = " << origArg << " --> " << llvmArg);
-      if (!isa<RankedTensorType>(origArg.getType())) {
-        // forward constants and scalars without chunking
-        assert(isa<PointerType>(origArg.getType()) ||
-               origArg.getType() == llvmArg.getType() &&
-                   "expected non-tensor arguments to be unchanged by type "
-                   "conversion");
-        chunkedArgs.push_back(op.getIns()[opIdx]);
-      } else if (Value ptrArg =
-                     getGenericOutputTensorAsPtr(op, opIdx, llvmArg)) {
-        // Load this tile's elements from the alloca produced by the prior
-        // generic, then pack them into the tile struct expected by the body.
-        Type tileStructTy = getTypeConverter()->convertType(origArg.getType());
-        auto structTy = cast<LLVM::LLVMStructType>(tileStructTy);
-        Type elemTy = structTy.getBody()[0];
-        auto b = TritonLLVMOpBuilder(loc, rewriter);
-        Value tileStruct = LLVM::UndefOp::create(rewriter, loc, tileStructTy);
-        for (unsigned j = 0; j < vectorSize; ++j) {
-          Value idx = b.i32_val(i * vectorSize + j);
-          Value gep = LLVM::GEPOp::create(
-              rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext()),
-              elemTy, ptrArg, ValueRange{idx});
-          Value elem = LLVM::LoadOp::create(rewriter, loc, elemTy, gep);
-          tileStruct =
-              LLVM::InsertValueOp::create(rewriter, loc, tileStruct, elem, {j});
-        }
-        chunkedArgs.push_back(UnrealizedConversionCastOp::create(
-                                  rewriter, loc, origArg.getType(), tileStruct)
-                                  .getResult(0));
-      } else {
-        Type convertedBodyType =
-            getTypeConverter()->convertType(origArg.getType());
-
-        Value chunk = LLVM::UndefOp::create(rewriter, loc, convertedBodyType);
-
-        for (unsigned j = 0; j < vectorSize; ++j) {
-          int64_t srcIndex = i * vectorSize + j;
-          LDBG("Read " << srcIndex);
-          Value extractedElement =
-              LLVM::ExtractValueOp::create(rewriter, loc, llvmArg, {srcIndex});
-          chunk = LLVM::InsertValueOp::create(rewriter, loc, chunk,
-                                              extractedElement, {j});
-        }
-
-        Value castedChunk = UnrealizedConversionCastOp::create(
-                                rewriter, loc, origArg.getType(), chunk)
-                                .getResult(0);
-        chunkedArgs.push_back(castedChunk);
-      }
-    }
-    return chunkedArgs;
-  }
-
   struct ArgInfo {
     enum class Kind { IV, IterArg, Ins };
 
@@ -350,12 +285,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       return ret;
     }
 
-    // TODO: delete me
-    ArrayRef<Value> getTensorAccPtrs() const { return materializedResults; }
-    ArrayRef<Type> getTensorElemTys() const {
-      return materializedResultElementTypes;
-    }
-
   private:
     SmallVector<ArgInfo> args;
     SmallVector<Value> loopIterArgs;
@@ -434,29 +363,16 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     Block *body = &op.getBody().front();
 
     IRMapping mapping;
-#if 1
     for (auto [bodyArg, newArg] :
          llvm::zip(body->getArguments(), chunkedArgs)) {
       mapping.map(bodyArg, newArg);
     }
-#else
-    // TODO: we should be able to handle all this in build args and just map
-    // body arguments -> args (making sure hte sizes match) IVs
-    for (auto [blockArg, offset] : llvm::zip(
-             body->getArguments().take_front(tileOffsets.size()), tileOffsets))
-      mapping.map(blockArg, offset);
-    // iter args: positions numIVs..numIVs+numIterArgs-1
-    for (auto [i, iterArgVal] : llvm::enumerate(iterArgVals))
-      mapping.map(body->getArgument(op.getNumInductionVars() + i), iterArgVal);
-    // ins args: positions insArgOffset..
-    for (auto [bodyArg, chunkedArg] :
-         llvm::zip(body->getArguments().drop_front(op.getInsArgOffset()),
-                   chunkedArgs))
-      mapping.map(bodyArg, chunkedArg);
-#endif
+
     unsigned numIterArgs = op.getNumIterArgs();
     SmallVector<Value> newIterArgVals, tensorTiles;
 
+    // clone the body remapping operands. When handling the. yield, track tiles
+    // requiring materialization separately
     for (Operation &bOp : *body) {
       if (auto yieldOp = dyn_cast<cpu::YieldOp>(bOp)) {
         if (yieldOp.getValues().empty())
@@ -474,40 +390,13 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     return {newIterArgVals, tensorTiles};
   }
 
-  void scatterTiles(ConversionPatternRewriter &rewriter, Location loc,
-                    ArrayRef<Value> tiles, Value tileOffset,
-                    unsigned vectorSize, ArrayRef<Value> tensorAccPtrs,
-                    ArrayRef<Type> tensorElemTys) const {
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
-    for (auto [tile, accPtr, elemTy] :
-         llvm::zip(tiles, tensorAccPtrs, tensorElemTys)) {
-      Type tileStructTy = getTypeConverter()->convertType(tile.getType());
-      Value llvmTile =
-          UnrealizedConversionCastOp::create(rewriter, loc, tileStructTy, tile)
-              .getResult(0);
-      for (unsigned j = 0; j < vectorSize; ++j) {
-        Value elem = LLVM::ExtractValueOp::create(rewriter, loc, llvmTile, {j});
-        Value idx =
-            LLVM::AddOp::create(rewriter, loc, tileOffset, b.i32_val(j));
-        Value gep = LLVM::GEPOp::create(
-            rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext()),
-            elemTy, accPtr, ValueRange{idx});
-        LLVM::StoreOp::create(rewriter, loc, elem, gep);
-      }
-    }
-  }
-
   // statically unroll all tiles. Required when any tensor input uses
   // llvm.extractvalue (which requires compile-time indices), or when there is
   // only one tile and loop overhead is unnecessary.
-  // iterArgVals is updated in-place to the final accumulated values.
   void emitUnrolled(cpu::GenericOp op, LoopHelper &helper,
                     ConversionPatternRewriter &rewriter, unsigned numChunks,
                     unsigned vectorSize, ArrayRef<int32_t> blockShape,
-                    ArrayRef<int32_t> tileShape,
-                    SmallVectorImpl<Value> &iterArgVals,
-                    ArrayRef<Value> tensorAccPtrs,
-                    ArrayRef<Type> tensorElemTys) const {
+                    ArrayRef<int32_t> tileShape) const {
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -521,13 +410,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     }
 
     for (unsigned i = 0; i < numChunks; ++i) {
-#if 1
-
-#else
-      SmallVector<Value> chunkedArgs =
-          buildStaticChunkedArgs(op, adaptor, rewriter, i, vectorSize);
-#endif
-
       SmallVector<Value> perDimOffsets(rank);
       unsigned remaining = i;
       LDBG("i = " << i);
@@ -549,10 +431,14 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
       Value flatOffset = b.i32_val(i * vectorSize);
       LDBG("flatOffset = " << (i * vectorSize));
-      auto [newIterArgVals, tiles] = cloneTileBody(op, rewriter, chunkedArgs);
-      iterArgVals.assign(newIterArgVals.begin(), newIterArgVals.end());
-      scatterTiles(rewriter, loc, tiles, flatOffset, vectorSize, tensorAccPtrs,
-                   tensorElemTys);
+      auto [newIterArgVals, loopTiles] =
+          cloneTileBody(op, rewriter, chunkedArgs);
+      helper.updateIterArgs(newIterArgVals);
+      SmallVector<Type> resultTypes =
+          llvm::map_to_vector(loopTiles, [&](Value tile) {
+            return getTypeConverter()->convertType(tile.getType());
+          });
+      helper.scatterResults(rewriter, loopTiles, resultTypes, vectorSize);
     }
   }
 
@@ -801,8 +687,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       LoopHelper helper(argInfos, iterArgVals, /*flatOffset=*/b.i32_val(0), op,
                         getTypeConverter(), rewriter);
       emitUnrolled(op, helper, rewriter, numChunks, vectorSize, blockShape,
-                   tileShape, iterArgVals, helper.getTensorAccPtrs(),
-                   helper.getTensorElemTys());
+                   tileShape);
       results = helper.getResults();
     } else {
       const bool genericHasTensorOutputs =

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -362,7 +362,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         argInfo.numElems = numElems;
         argInfo.llvmType = getTypeConverter()->convertType(origArg.getType());
       } else {
-        argInfo.llvmType = llvmArg.getType();
+        argInfo.llvmType = getTypeConverter()->convertType(origArg.getType());
         if (isa<RankedTensorType>(argInfo.tritonType)) {
           // tensor arguments that aren't backed by an alloca need to store the
           // adaptor value so they can be sliced when inputs to the cloned loop

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -13,6 +13,39 @@ using namespace mlir::triton;
 
 namespace {
 
+static Value allocateGlobalBuffer(ConversionPatternRewriter &rewriter,
+                                  Location loc, Type elemTy, unsigned numElems,
+                                  unsigned nameIdx, cpu::GenericOp generic) {
+  auto func = generic->getParentOfType<LLVM::LLVMFuncOp>();
+  assert(func && "expected generic op to be inside an LLVM function");
+  auto module = generic->getParentOfType<ModuleOp>();
+  assert(module && "expected generic op to be inside a module");
+
+  auto globalArrayTy = LLVM::LLVMArrayType::get(elemTy, numElems);
+
+  std::string globalName;
+  do {
+    globalName = (func.getName() + "_tac_" + std::to_string(nameIdx++)).str();
+  } while (module.lookupSymbol(globalName));
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(module.getBody());
+    LLVM::GlobalOp::create(rewriter, loc, globalArrayTy,
+                           /*isConstant=*/false, LLVM::Linkage::Internal,
+                           globalName, Attribute{},
+                           /*alignment=*/4, /*addrSpace=*/0,
+                           /*dsoLocal=*/false, /*threadLocal=*/true);
+  }
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(&func.getBody().front());
+  LDBG("Creating thread local global allocation `"
+       << globalName << "` for tensor of size " << numElems);
+  Value globalPtr = LLVM::AddressOfOp::create(
+      rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext()),
+      globalName);
+  return globalPtr;
+}
+
 struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
   using ConvertOpToLLVMPattern<cpu::GenericOp>::ConvertOpToLLVMPattern;
 
@@ -131,10 +164,39 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
   class LoopHelper {
   public:
     LoopHelper(ArrayRef<ArgInfo> args, ArrayRef<Value> loopIterArgs,
-               Value flatOffset)
+               Value flatOffset, cpu::GenericOp generic,
+               const TypeConverter *typeConverter,
+               ConversionPatternRewriter &rewriter)
         : args(args.begin(), args.end()),
           loopIterArgs(loopIterArgs.begin(), loopIterArgs.end()),
-          flatOffset(flatOffset) {}
+          flatOffset(flatOffset) {
+
+      // Create temporary buffers in thread local global memory for materialized
+      // results. This avoids loop-carried <blockSize x elemTy> phi nodes
+      // which would allocate tens of kilobytes on the stack and cause stack
+      // overflows for large block sizes (e.g. blockSize=4096).
+      //
+      // Globals are addressed via AddressOf in the function entry block so the
+      // pointer dominates all uses. Each thread gets its own copy since the
+      // globals are thread-local.
+      //
+      // TODO: we should probably check that generic results are only used by
+      // other generics or we will run into conversion problems
+      for (auto [i, resultTy] : llvm::enumerate(llvm::drop_begin(
+               generic.getResultTypes(), generic.getNumIterArgs()))) {
+        auto tensorTy = cast<RankedTensorType>(resultTy);
+        int64_t tensorElems = std::accumulate(tensorTy.getShape().begin(),
+                                              tensorTy.getShape().end(),
+                                              int64_t{1}, std::multiplies<>());
+        Type elemTy = typeConverter->convertType(tensorTy.getElementType());
+        materializedResultElementTypes.push_back(elemTy);
+
+        Value globalPtr = allocateGlobalBuffer(
+            rewriter, generic.getResult(i + generic.getNumIterArgs()).getLoc(),
+            elemTy, tensorElems, materializedResults.size(), generic);
+        materializedResults.push_back(globalPtr);
+      }
+    }
 
     SmallVector<Value> getEntryArgs() {
       return {tileOffsets.begin(), tileOffsets.end()};
@@ -211,13 +273,43 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       return blockArgs;
     }
 
+    void scatterResults(ConversionPatternRewriter &rewriter,
+                        ArrayRef<Value> results, ArrayRef<Type> resultTypes,
+                        unsigned vectorSize) {
+      for (auto [tile, tileType, ptr, elemTy] :
+           llvm::zip(results, resultTypes, materializedResults,
+                     materializedResultElementTypes)) {
+        Location loc = tile.getLoc(); // or ptr?
+        auto b = TritonLLVMOpBuilder(loc, rewriter);
+        auto llvmStruct = cast<LLVM::LLVMStructType>(tileType);
+        Value llvmTile =
+            UnrealizedConversionCastOp::create(rewriter, loc, tileType, tile)
+                .getResult(0);
+        // TODO: should this be vector size or should we read the number of
+        // elements from the tile struct?
+        for (unsigned j = 0; j < vectorSize; ++j) {
+          Value elem = b.extract_val(llvmStruct.getBody()[j], llvmTile, j);
+          Value idx = b.add(flatOffset, b.i32_val(j));
+          Value gep = b.gep(ptr_ty(rewriter.getContext()), elemTy, ptr,
+                            ValueRange{idx});
+          b.store(elem, gep);
+        }
+      }
+    }
+
     // TODO: delete me
-    Value getFlatOffset() const { return flatOffset; }
+    ArrayRef<Value> getTensorAccPtrs() const { return materializedResults; }
+    ArrayRef<Type> getTensorElemTys() const {
+      return materializedResultElementTypes;
+    }
 
   private:
     SmallVector<ArgInfo> args;
     SmallVector<Value> loopIterArgs;
+
     SmallVector<Value> materializedResults;
+    SmallVector<Type> materializedResultElementTypes;
+
     SmallVector<Value> tileOffsets;
     Value flatOffset;
   };
@@ -461,8 +553,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                        ConversionPatternRewriter &rewriter, unsigned dim,
                        ArrayRef<Value> blockShape, ArrayRef<int32_t> tileShape,
                        unsigned vectorSize, SmallVectorImpl<Value> &iterArgVals,
-                       ArrayRef<Value> tensorAccPtrs,
-                       ArrayRef<Type> tensorElemTys,
                        Block *innerAfterBlock = nullptr) const {
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -508,8 +598,12 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         // scatter non-iter-arg tensor tiles
         SmallVector<Value> loopTiles(yieldOp.getValues().begin() + numIterArgs,
                                      yieldOp.getValues().end());
-        scatterTiles(rewriter, loc, loopTiles, helper.getFlatOffset(),
-                     vectorSize, tensorAccPtrs, tensorElemTys);
+        SmallVector<Type> resultTypes =
+            llvm::map_to_vector(loopTiles, [&](Value tile) {
+              return getTypeConverter()->convertType(tile.getType());
+            });
+        helper.scatterResults(rewriter, loopTiles, resultTypes, vectorSize);
+
 
         rewriter.eraseOp(yieldOp);
         rewriter.setInsertionPointToEnd(&block);
@@ -538,8 +632,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           SmallVector<Value> innerIterArgVals(currentCarried.begin(),
                                               currentCarried.end());
           emitNestedLoops(op, adaptor, helper, rewriter, dim + 1, blockShape,
-                          tileShape, vectorSize, innerIterArgVals,
-                          tensorAccPtrs, tensorElemTys, afterBlock);
+                          tileShape, vectorSize, innerIterArgVals, afterBlock);
           helper.popTileOffset();
           return innerIterArgVals;
         });
@@ -582,60 +675,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                               << ", numElems = " << argInfo.numElems);
     }
 
-    // Tensor results are materialized as thread-local global arrays rather than
-    // LLVM vectors. This avoids loop-carried <blockSize x elemTy> phi nodes
-    // which would allocate tens of kilobytes on the stack and cause stack
-    // overflows for large block sizes (e.g. blockSize=4096).
-    //
-    // Globals are addressed via AddressOf in the function entry block so the
-    // pointer dominates all uses. Each thread gets its own copy since the
-    // globals are thread-local.
-    //
-    // TODO: we should probably check that generic results are only used by
-    // other generics or we will run into conversion problems
-    SmallVector<Value> tensorAccPtrs;
-    SmallVector<Type> tensorElemTys;
-    auto func = op->getParentOfType<LLVM::LLVMFuncOp>();
-    assert(func && "expected generic op to be inside an LLVM function");
-    auto module = op->getParentOfType<ModuleOp>();
-    assert(module && "expected generic op to be inside a module");
-    for (Type resultTy :
-         llvm::drop_begin(op.getResultTypes(), op.getNumIterArgs())) {
-      auto tensorTy = cast<RankedTensorType>(resultTy);
-      int64_t tensorElems = std::accumulate(tensorTy.getShape().begin(),
-                                            tensorTy.getShape().end(),
-                                            int64_t{1}, std::multiplies<>());
-      Type elemTy = getTypeConverter()->convertType(tensorTy.getElementType());
-      tensorElemTys.push_back(elemTy);
-
-      auto globalArrayTy = LLVM::LLVMArrayType::get(elemTy, tensorElems);
-      std::string globalName;
-      unsigned nameIdx = tensorAccPtrs.size();
-      do {
-        globalName =
-            (func.getName() + "_tac_" + std::to_string(nameIdx++)).str();
-      } while (module.lookupSymbol(globalName));
-      {
-        OpBuilder::InsertionGuard guard(rewriter);
-        rewriter.setInsertionPointToStart(module.getBody());
-        LLVM::GlobalOp::create(rewriter, loc, globalArrayTy,
-                               /*isConstant=*/false, LLVM::Linkage::Internal,
-                               globalName, Attribute{},
-                               /*alignment=*/4, /*addrSpace=*/0,
-                               /*dsoLocal=*/false, /*threadLocal=*/true);
-      }
-      OpBuilder::InsertionGuard guard(rewriter);
-      rewriter.setInsertionPointToStart(&func.getBody().front());
-      LDBG("Creating thread local global allocation `"
-           << globalName << "` for tensor of size " << tensorElems);
-      Value globalPtr = LLVM::AddressOfOp::create(
-          rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext()),
-          globalName);
-      tensorAccPtrs.push_back(globalPtr);
-    }
-
-    Block *body = &op.getBody().front();
-
     // Tensor args passed as LLVM structs require static tile indices
     // (llvm.extractvalue only accepts attribute indices). Alloca-backed tensors
     // from a prior generic are GEP-indexed and support dynamic offsets.
@@ -670,14 +709,21 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
              "tensor args that require materialization";
       return failure();
     }
+
+    SmallVector<Value> materializedTensorResults;
     if (requiresTensorArgMaterialization || numChunks == 1) {
       assert(numChunks > 0 && "expected numChunks to be positive when required "
                               "or statically computable");
       assert(blockShape.size() == tileShape.size() &&
              "expected blockShape and tileShape to have "
              "the same rank");
+      LoopHelper helper(argInfos, iterArgVals, /*flatOffset=*/nullptr, op,
+                        getTypeConverter(), rewriter);
       emitUnrolled(op, adaptor, rewriter, numChunks, vectorSize, blockShape,
-                   tileShape, iterArgVals, tensorAccPtrs, tensorElemTys);
+                   tileShape, iterArgVals, helper.getTensorAccPtrs(),
+                   helper.getTensorElemTys());
+      materializedTensorResults.append(helper.getTensorAccPtrs().begin(),
+                                       helper.getTensorAccPtrs().end());
     } else {
       const bool genericHasTensorOutputs =
           llvm::any_of(op->getResults(), [](Value result) {
@@ -693,20 +739,19 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                                    "generic ops on dynamic path");
 
       auto b = TritonLLVMOpBuilder(loc, rewriter);
-      LoopHelper helper(argInfos, iterArgVals, /*flatOffset=*/b.i32_val(0));
+      LoopHelper helper(argInfos, iterArgVals, /*flatOffset=*/b.i32_val(0), op,
+                        getTypeConverter(), rewriter);
       SmallVector<Value> blockShapeVals(op.getBlockShape().begin(),
                                         op.getBlockShape().end());
       emitNestedLoops(op, adaptor, helper, rewriter, /*dim=*/0, blockShapeVals,
-                      tileShape, vectorSize, iterArgVals, tensorAccPtrs,
-                      tensorElemTys);
+                      tileShape, vectorSize, iterArgVals);
+      materializedTensorResults.append(helper.getTensorAccPtrs().begin(),
+                                       helper.getTensorAccPtrs().end());
     }
 
-    // Collect all replacement values atomically. Mixing replaceAllUsesWith +
-    // eraseOp in a ConversionPatternRewriter causes double-replacement
-    // assertions in the framework; a single replaceOp call avoids that.
-    unsigned numIterArgs = op.getNumIterArgs();
     SmallVector<Value> allReplacements(iterArgVals.begin(), iterArgVals.end());
-    allReplacements.append(tensorAccPtrs);
+    allReplacements.append(materializedTensorResults.begin(),
+                           materializedTensorResults.end());
     if (allReplacements.empty())
       rewriter.eraseOp(op);
     else

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -117,6 +117,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     Kind kind;
     Type tritonType;
     Type llvmType;
+    Value operand;
 
     Value bufferPtr;       // only for global memory backed args
     unsigned numElems = 0; // only for global memory backed args
@@ -146,6 +147,68 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     void updateFlatOffset(ConversionPatternRewriter &rewriter, Value inc) {
       auto b = TritonLLVMOpBuilder(flatOffset.getLoc(), rewriter);
       flatOffset = b.add(flatOffset, inc);
+    }
+
+    SmallVector<Value>
+    getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
+                         unsigned vectorSize,
+                         SmallVectorImpl<Value> &iterArgVals) {
+      // start with IVs
+      SmallVector<Value> blockArgs = {tileOffsets.begin(), tileOffsets.end()};
+
+      // Add iter args -- TODO: remove from function arg and hold this state in
+      // the class
+      blockArgs.append(iterArgVals.begin(), iterArgVals.end());
+
+      // Add ins args
+      for (const auto &argInfo : args) {
+        if (argInfo.kind == ArgInfo::Kind::Ins) {
+          Location loc = argInfo.operand.getLoc();
+
+          if (argInfo.bufferPtr) {
+            // load this tiles elements from the global buffer
+            auto tileStructTy = cast<LLVM::LLVMStructType>(argInfo.llvmType);
+            Type elemTy = tileStructTy.getBody()[0];
+            Value tileStruct =
+                LLVM::UndefOp::create(rewriter, loc, tileStructTy);
+            // TODO: should this be vectorSize?
+            auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+            for (unsigned j = 0; j < vectorSize; ++j) {
+              Value globalIdx =
+                  LLVM::AddOp::create(rewriter, loc, flatOffset, b.i32_val(j));
+              Value gep = LLVM::GEPOp::create(
+                  rewriter, loc,
+                  LLVM::LLVMPointerType::get(rewriter.getContext()), elemTy,
+                  argInfo.bufferPtr, ValueRange{globalIdx});
+              Value elem = LLVM::LoadOp::create(rewriter, loc, elemTy, gep);
+              tileStruct = LLVM::InsertValueOp::create(rewriter, loc,
+                                                       tileStruct, elem, {j});
+            }
+            blockArgs.push_back(tileStruct);
+          } else if (isa<PointerType>(argInfo.tritonType)) {
+            // we might have a tt.ptr hiding in an unrealized conversion cast
+            // due to late conversion of generic op block arguments. Use
+            // unrealized conversion cast which will be folded away later
+            if (argInfo.tritonType != argInfo.llvmType) {
+              blockArgs.push_back(
+                  UnrealizedConversionCastOp::create(
+                      rewriter, loc, argInfo.llvmType, argInfo.operand)
+                      .getResult(0));
+            } else {
+              blockArgs.push_back(argInfo.operand);
+            }
+          } else {
+            assert(!isa<RankedTensorType>(argInfo.tritonType));
+            assert(argInfo.tritonType == argInfo.llvmType &&
+                   "expected non-tensor arguments to be unchanged by type "
+                   "conversion");
+            blockArgs.push_back(argInfo.operand);
+          }
+        }
+      }
+
+      return blockArgs;
     }
 
     // TODO: delete me
@@ -193,6 +256,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       argInfo.kind = ArgInfo::Kind::Ins;
 
       argInfo.tritonType = origArg.getType();
+      argInfo.operand = op.getIns()[i];
       Value ptrArg = getGenericOutputTensorAsPtr(op, i, llvmArg);
       if (ptrArg) {
         auto allocationTensorTy = cast<RankedTensorType>(ins[i].getType());
@@ -277,66 +341,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         LLVM::StoreOp::create(rewriter, loc, elem, gep);
       }
     }
-  }
-
-  // Builds tile args for a dynamic tile at runtime offset tileOffset.
-  // Mirrors buildStaticChunkedArgs but uses a runtime Value for the offset
-  // instead of a compile-time index. Only valid for temporary storage backed
-  // tensor args and non-tensor args — statically-indexed tensor args must use
-  // the unrolled path.
-  SmallVector<Value>
-  buildDynamicChunkedArgs(cpu::GenericOp op, OpAdaptor adaptor,
-                          ConversionPatternRewriter &rewriter, Value tileOffset,
-                          unsigned vectorSize) const {
-    Location loc = op.getLoc();
-    Block *body = &op.getBody().front();
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
-    SmallVector<Value> tileArgs;
-
-    for (auto [opIdx, origArg, llvmArg] :
-         llvm::enumerate(body->getArguments().drop_front(op.getInsArgOffset()),
-                         adaptor.getIns())) {
-      if (Value ptrArg = getGenericOutputTensorAsPtr(op, opIdx, llvmArg)) {
-        // Load this tile's elements from the alloca produced by the prior
-        // generic and pack them into the tile struct.
-        Type tileStructTy = getTypeConverter()->convertType(origArg.getType());
-        auto structTy = cast<LLVM::LLVMStructType>(tileStructTy);
-        Type elemTy = structTy.getBody()[0];
-        Value tileStruct = LLVM::UndefOp::create(rewriter, loc, tileStructTy);
-        for (unsigned j = 0; j < vectorSize; ++j) {
-          Value globalIdx =
-              LLVM::AddOp::create(rewriter, loc, tileOffset, b.i32_val(j));
-          Value gep = LLVM::GEPOp::create(
-              rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext()),
-              elemTy, ptrArg, ValueRange{globalIdx});
-          Value elem = LLVM::LoadOp::create(rewriter, loc, elemTy, gep);
-          tileStruct =
-              LLVM::InsertValueOp::create(rewriter, loc, tileStruct, elem, {j});
-        }
-        tileArgs.push_back(tileStruct);
-      } else if (isa<PointerType>(origArg.getType())) {
-        // we might have a tt.ptr hiding in an unrealized conversion cast due to
-        // late conversion of generic op block arguments. Use unrealized
-        // conversion cast which will be folded away later
-        if (origArg.getType() != llvmArg.getType()) {
-          tileArgs.push_back(
-              UnrealizedConversionCastOp::create(
-                  rewriter, loc, llvmArg.getType(), op.getIns()[opIdx])
-                  .getResult(0));
-        } else {
-          tileArgs.push_back(op.getIns()[opIdx]);
-        }
-      } else {
-        assert(!isa<RankedTensorType>(origArg.getType()) &&
-               "tensor types are not allowed in compile-time generated "
-               "generic tile loops");
-        assert(origArg.getType() == llvmArg.getType() &&
-               "expected non-tensor arguments to be unchanged by type "
-               "conversion");
-        tileArgs.push_back(op.getIns()[opIdx]);
-      }
-    }
-    return tileArgs;
   }
 
   // statically unroll all tiles. Required when any tensor input uses
@@ -474,8 +478,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       Block *bodyEntry = &bodyRegion.front();
 
       // build tile args before inlining (references block arguments)
-      auto tileArgs = buildDynamicChunkedArgs(
-          op, adaptor, rewriter, helper.getFlatOffset(), vectorSize);
+      auto entryArgs =
+          helper.getLoopBodyBlockArgs(rewriter, vectorSize, iterArgVals);
 
       rewriter.inlineRegionBefore(bodyRegion, *innerAfterBlock->getParent(),
                                   innerAfterBlock->getIterator());
@@ -486,14 +490,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       bodyEntry = rewriter.applySignatureConversion(bodyEntry, sigConv,
                                                     getTypeConverter());
 
-      // entryArgs: [IVs..., iterArgs..., insArgs...]
-      SmallVector<Value> entryArgs = helper.getEntryArgs();
-      for (auto arg : iterArgVals)
-        LDBG("iterArgVals: " << arg);
-      entryArgs.append(iterArgVals.begin(), iterArgVals.end());
-      for (auto arg : tileArgs)
-        LDBG("tileArgs: " << arg);
-      entryArgs.append(tileArgs.begin(), tileArgs.end());
       LLVM::BrOp::create(rewriter, loc, entryArgs, bodyEntry);
 
       unsigned numIterArgs = op.getNumIterArgs();


### PR DESCRIPTION
Splits the generic op to llvm pass into two stages:
1. Create block argument info (`ArgInfo`) from GenericOp state. Arg infos also record type conversions. 
2. Lower the generic op body to tiled loops (possibly unrolled), using the `LoopHelper` to handle state. 

This has a few advantages:
* Removes duplication in block argument processing (static vs dynamic chunk args)
* Simplifies the emitNestedLoops/emitUnrolled function bodies by hiding implementation in the helper and simplifying signatures 
* Makes the block argument state very clear up front and confines state mutations to loop helper (which we could introspect during lowering if needed) 

I also tried to cleanup the location usage so block argument replacements keep the location from their original arguments instead of just using the generic op location. 
