### PR TITLE
Support fusing tiled K loops into GenericOp block/tile shapes

### DIFF
--- a/.github/workflows/integration-tests-cpu.yml
+++ b/.github/workflows/integration-tests-cpu.yml
@@ -111,7 +111,7 @@ jobs:
         env:
           TRITON_DEFAULT_BACKEND: "cpu"
         run: |
-            TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python ../python/tutorials/02-fused-softmax.py
+            TRITON_CPU_ENABLE_TILE_AND_FUSE=1 TRITON_ALWAYS_COMPILE=1 python ../python/tutorials/02-fused-softmax.py
             TRITON_CPU_ENABLE_TILE_AND_FUSE=1 TRITON_ALWAYS_COMPILE=1 python ../python/tutorials/03-matrix-multiplication.py
 
       # Triton tests.

--- a/.github/workflows/integration-tests-macos.yml
+++ b/.github/workflows/integration-tests-macos.yml
@@ -124,8 +124,8 @@ jobs:
           TRITON_DEFAULT_BACKEND: "cpu"
         run: |
             source ~/.venv/bin/activate
-            TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python ../python/tutorials/02-fused-softmax.py
-            python ../python/tutorials/03-matrix-multiplication.py
+            TRITON_CPU_ENABLE_TILE_AND_FUSE=1 TRITON_ALWAYS_COMPILE=1 python ../python/tutorials/02-fused-softmax.py
+            TRITON_CPU_ENABLE_TILE_AND_FUSE=1 TRITON_ALWAYS_COMPILE=1 python ../python/tutorials/03-matrix-multiplication.py
 
       - name: Run lit tests
         working-directory: ./triton

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -287,7 +287,7 @@ static void _launch(int num_warps, int shared_memory, int gridX, int gridY, int 
         void *cpu_barrier = &barrier;
 
         for (int lane_id = 0; lane_id < warp_size; lane_id++) {{
-            fibers.emplace_back([&, block_start, run_end, lane_id]() {{
+            fibers.emplace_back(std::allocator_arg, boost::fibers::fixedsize_stack(8 * 1024 * 1024), [&, block_start, run_end, lane_id]() {{
                 int32_t launch_id[] = {{
                     (int32_t)block_start, (int32_t)run_end, lane_id, 0, 0
                 }};

--- a/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/cpu/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -55,10 +55,6 @@ LogicalResult GenericOp::verify() {
         return emitOpError("expects blockShape[")
                << i << "] % tileShape[" << i << "] == 0, got " << bv << " vs "
                << tileShape[i];
-    } else {
-      return emitOpError("only constant block shapes are currently supported "
-                         "for verification, got ")
-             << blockShape[i];
     }
   }
 
@@ -108,15 +104,6 @@ LogicalResult GenericOp::verify() {
            << bodyBlock.getNumArguments() << " argument(s) but expects "
            << expectedArgs << " (numIVs=" << numInductionVars
            << " + numIns=" << numIns << " + numIterArgs=" << numIterArgs << ")";
-
-  // Each iter arg block arg type must match the corresponding init_vals type.
-  for (auto [i, initVal] : llvm::enumerate(initVals)) {
-    BlockArgument iterArg = bodyBlock.getArgument(numInductionVars + i);
-    if (iterArg.getType() != initVal.getType())
-      return emitOpError("body iter arg ")
-             << i << " has type " << iterArg.getType() << " but init_vals[" << i
-             << "] has type " << initVal.getType();
-  }
 
   // ttc.yield leading values must match iter arg types.
   // The body may have multiple blocks after SCF-to-CF lowering (e.g. a K-loop

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -166,6 +166,7 @@ static Block *initGenericBody(OpBuilder &rewriter, cpu::GenericOp generic,
                       generic.getLoc()); // tile offset per vector shape dim
 
   // Iter args before ins args — one block arg per reduction dim init val.
+  // TODO: support passing these as parameters so we can tile them
   for (Value initVal : generic.getInitVals())
     body->addArgument(initVal.getType(), initVal.getLoc());
 
@@ -1375,8 +1376,6 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
     Block *newBody = initGenericBody(rewriter, newGeneric, newTiledIns,
                                      newTileShapes, mapping);
 
-    llvm::errs() << "new generic = " << newGeneric << "\n";
-
     // 5. wire up body arg mappings
     // Generic tile loop IVs
     for (unsigned i = 0; i < genericOp.getNumInductionVars(); i++)
@@ -1384,6 +1383,11 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
 
     // old acc body arg -> new acc tile iter arg
     mapping.map(oldBody.getArgument(accBodyArgPos), newGeneric.getIterArg(0));
+
+    // other kept body args -> new body args
+    for (auto [newPos, entry] : llvm::enumerate(keptIns))
+      mapping.map(oldBody.getArgument(entry.oldBodyArgPos),
+                  newBody->getArgument(newGeneric.getInsArgOffset() + newPos));
 
     // K loop IV
     for (auto pos : kIVBodyArgPositions)
@@ -1400,8 +1404,9 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
     llvm::errs() << "new generic with cloned body: " << newGeneric << "\n";
 
     // 7. replace old op
-    rewriter.replaceAllUsesWith(forOp.getResults(), newGeneric.getResults());
-    rewriter.eraseOp(forOp);
+    // rewriter.replaceAllUsesWith(forOp.getResults(), newGeneric.getResults());
+    // rewriter.eraseOp(forOp);
+    rewriter.replaceOp(forOp, newGeneric.getResults());
 #if 0
 
 

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -944,7 +944,7 @@ struct FuseConvertLayoutOpIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
 struct FuseParentForOpIntoGeneric : mlir::OpRewritePattern<scf::ForOp> {
   using OpRewritePattern<scf::ForOp>::OpRewritePattern;
 
-  std::optional<cpu::GenericOp> findTargetGenericOp(scf::ForOp forOp) const {
+  static std::optional<cpu::GenericOp> findTargetGenericOp(scf::ForOp forOp) {
     // (1) For loop must have iter args — excludes persistent block-dispatch
     // loops which have no iter args.
     if (forOp.getNumRegionIterArgs() == 0)
@@ -1213,6 +1213,127 @@ struct FuseParentForOpIntoGeneric : mlir::OpRewritePattern<scf::ForOp> {
   }
 };
 
+struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+
+  static std::optional<std::pair<cpu::GenericOp, triton::DotOp>>
+  findTargetGenericOp(scf::ForOp forOp) {
+
+    // step must be 1
+    if (!matchPattern(forOp.getStep(), m_One()))
+      return std::nullopt;
+
+    auto numIterArgs = forOp.getNumRegionIterArgs();
+    if (numIterArgs != 1)
+      return std::nullopt;
+
+    // body must contain exactly 1 generic op and a scf.yield
+    cpu::GenericOp genericOp;
+    for (auto &op : forOp.getBody()->without_terminator()) {
+      if (auto bodyGenericOp = dyn_cast<cpu::GenericOp>(op)) {
+        if (genericOp) {
+          return std::nullopt; // >1 generic
+        }
+        genericOp = bodyGenericOp;
+      } else {
+        return std::nullopt; // unexpected op in for body
+      }
+    }
+    if (!genericOp)
+      return std::nullopt;
+
+    // ensure the sole loop carried iter arg is the dot op accumulator
+    triton::DotOp dotOp;
+    BlockArgument accArg = forOp.getRegionIterArg(0);
+    for (auto [i, operand] : llvm::enumerate(genericOp.getIns())) {
+      if (operand == accArg) {
+        BlockArgument genericBodyArg = genericOp.getIterArg(i);
+        for (auto user : genericBodyArg.getUsers()) {
+          if (auto crtDotOp = dyn_cast<triton::DotOp>(user)) {
+            dotOp = crtDotOp;
+            if (genericBodyArg != dotOp.getC())
+              return std::nullopt; // loop carried iter arg is not the
+                                   // accumulator
+          }
+        }
+      }
+    }
+    if (!dotOp)
+      return std::nullopt;
+
+    return std::make_pair(genericOp, dotOp);
+  }
+
+  LogicalResult
+  matchAndRewrite(scf::ForOp forOp,
+                  mlir::PatternRewriter &rewriter) const override {
+
+    auto targetGenericOp = findTargetGenericOp(forOp);
+    if (!targetGenericOp)
+      return failure();
+
+    auto [genericOp, dotOp] = *targetGenericOp;
+    llvm::errs() << "candidate for op: " << forOp << "\n";
+
+    auto aOperandType = cast<RankedTensorType>(dotOp.getA().getType());
+    gpu::BlockedEncodingAttr aOperandEncoding =
+        dyn_cast<gpu::BlockedEncodingAttr>(aOperandType.getEncoding());
+    if (!aOperandEncoding) {
+      auto aDotOperandEncoding =
+          cast<gpu::DotOperandEncodingAttr>(aOperandType.getEncoding());
+      aOperandEncoding =
+          cast<gpu::BlockedEncodingAttr>(aDotOperandEncoding.getParent());
+    }
+
+    auto [blockShape, tileShape] =
+        getBlockAndTileShapes(aOperandType, aOperandEncoding);
+    int32_t kTileShape =
+        blockShape[1]; // use the block shape as the kTile shape. The k block
+                       // shape is the runtime value of K (the for loop upper
+                       // bound)
+    llvm::errs() << "m, k block shape: ";
+    for (auto s : blockShape)
+      llvm::errs() << s << " ";
+    llvm::errs() << "\nm, k tile shape: ";
+    for (auto s : tileShape)
+      llvm::errs() << s << " ";
+    llvm::errs() << "\n";
+
+    // 1. compute the K tiling information and re-create the generic to support
+    // tiling over the K dimension. The new generic will be [K, M, N] tiled
+    rewriter.setInsertionPoint(forOp);
+    auto kSizeLoc = forOp.getUpperBound().getLoc();
+    Value kTileConst = arith::ConstantOp::create(
+        rewriter, kSizeLoc, rewriter.getI32IntegerAttr(kTileShape));
+    Value kSize = arith::MulIOp::create(rewriter, kSizeLoc,
+                                        forOp.getUpperBound(), kTileConst);
+
+    SmallVector<Value> newBlockShapes = {kSize, genericOp.getBlockShape()[0],
+                                         genericOp.getBlockShape()[1]};
+    SmallVector<int32_t> newTileShapes = {
+        kTileShape, genericOp.getTileShape()[0], genericOp.getTileShape()[1]};
+
+    SmallVector<Value> initVals =
+        forOp.getInitArgs(); // TODO: likely have to tile the accumulator?
+
+    auto newGeneric = cpu::GenericOp::create(
+        rewriter, genericOp.getLoc(), genericOp.getResultTypes(), initVals,
+        genericOp.getIns(), newBlockShapes, newTileShapes,
+        /*reductionDims=*/{0});
+    llvm::errs() << "created new generic: " << newGeneric << "\n";
+
+    // 2. clone the old generic body into the new generic. we need to take care to map the induction variable and loop carried dependency, as well as update the K dimension of any tiled operands to use the new tile shape
+
+    Block &genericBody = genericOp.getBody().front();
+
+    IRMapping mapping;
+
+    assert(false && "todo");
+
+    return failure();
+  }
+};
+
 } // namespace
 
 struct TritonCPUTileAndFusePass
@@ -1247,6 +1368,7 @@ struct TritonCPUTileAndFusePass
     fusePatterns.add<FuseConstantIntoGeneric>(context, benefitDefault);
     fusePatterns.add<FuseConvertLayoutOpIntoGeneric>(context, benefitDefault);
 
+    fusePatterns.add<TileKLoop>(context, benefitDefault + 10);
     fusePatterns.add<FuseParentForOpIntoGeneric>(context, benefitDefault);
 
     if (applyPatternsGreedily(m, std::move(fusePatterns)).failed()) {

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -1399,11 +1399,11 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
     Value kElemOffset = newBody->getArgument(0);
     Value kTileIdxConst = arith::ConstantOp::create(
         rewriter, forOp.getLoc(), rewriter.getI32IntegerAttr(kTileShape));
-    Value kTileIdx =
-        arith::DivSIOp::create(rewriter, forOp.getLoc(), kElemOffset, kTileIdxConst);
+    Value kTileIdx = arith::DivSIOp::create(rewriter, forOp.getLoc(),
+                                            kElemOffset, kTileIdxConst);
     for (auto pos : kIVBodyArgPositions)
       mapping.map(oldBody.getArgument(pos), kTileIdx);
-      
+
     for (Operation &op : oldBody.without_terminator())
       rewriter.clone(op, mapping);
     auto oldYield = cast<cpu::YieldOp>(oldBody.getTerminator());

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -158,7 +158,7 @@ struct TiledInput {
 // of the block. Init values for iter args come first, then ins args. Returns
 // the new block.
 static Block *initGenericBody(OpBuilder &rewriter, cpu::GenericOp generic,
-                              ArrayRef<TiledInput> ins,
+                              ArrayRef<TiledInput> ins, ArrayRef<Type> iterArgs,
                               ArrayRef<int32_t> tileShape, IRMapping &mapping) {
   Block *body = rewriter.createBlock(&generic.getBody());
   for (unsigned i = 0; i < tileShape.size(); i++)
@@ -166,9 +166,9 @@ static Block *initGenericBody(OpBuilder &rewriter, cpu::GenericOp generic,
                       generic.getLoc()); // tile offset per vector shape dim
 
   // Iter args before ins args — one block arg per reduction dim init val.
-  // TODO: support passing these as parameters so we can tile them
-  for (Value initVal : generic.getInitVals())
-    body->addArgument(initVal.getType(), initVal.getLoc());
+  assert(iterArgs.size() == generic.getInitVals().size());
+  for (auto [i, iterArgType] : llvm::enumerate(iterArgs))
+    body->addArgument(iterArgType, generic.getInitVals()[i].getLoc());
 
   for (auto pair : ins) {
     auto [v, inputTileShape] = pair;
@@ -216,7 +216,7 @@ struct WrapStores : public mlir::OpRewritePattern<triton::StoreOp> {
                                insValues, blockShapeValues, tileShape);
 
     IRMapping bodyMapping;
-    initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
+    initGenericBody(rewriter, generic, ins, {}, tileShape, bodyMapping);
 
     rewriter.clone(*storeOp, bodyMapping);
     cpu::YieldOp::create(rewriter, loc, /*values=*/ValueRange{});
@@ -303,7 +303,8 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
                                /*reductionDims=*/{0});
 
     IRMapping bodyMapping;
-    initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
+    initGenericBody(rewriter, generic, ins, {initVals[0].getType()}, tileShape,
+                    bodyMapping);
 
     // Clone the reduce — it now operates on the tile-sized tensor.
     auto *newReduce = rewriter.clone(*reduceOp, bodyMapping);
@@ -390,7 +391,7 @@ struct WrapDotOp : public mlir::OpRewritePattern<triton::DotOp> {
                                           blockShapeValues, tileShape);
 
     IRMapping bodyMapping;
-    initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
+    initGenericBody(rewriter, generic, ins, {}, tileShape, bodyMapping);
 
     // clone the dot op
     auto *newDot = rewriter.clone(*dotOp, bodyMapping);
@@ -467,7 +468,7 @@ struct WrapConvertLayoutOp
                                insValues, blockShapeValues, tileShape);
 
     IRMapping bodyMapping;
-    initGenericBody(rewriter, generic, ins, tileShape, bodyMapping);
+    initGenericBody(rewriter, generic, ins, {}, tileShape, bodyMapping);
 
     auto newCvt = rewriter.clone(*cvtOp, bodyMapping);
     newCvt->getResult(0).setType(updateTensorType(dstTy, tileShape));
@@ -1284,7 +1285,6 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
       return failure();
 
     auto [genericOp, dotOp] = *targetGenericOp;
-    llvm::errs() << "candidate for op: " << forOp << "\n";
 
     // 1. partition inputs, drop existing for loop inputs
     Value kIV = forOp.getInductionVar();
@@ -1357,6 +1357,9 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
                                          genericOp.getBlockShape()[1]};
     SmallVector<int32_t> newTileShapes = {
         kTileShape, genericOp.getTileShape()[0], genericOp.getTileShape()[1]};
+    Type accIterArgType =
+        updateTensorType(dotOp.getC().getType(), {genericOp.getTileShape()[0],
+                                                  genericOp.getTileShape()[1]});
 
     // 3. Build new TiledInput list
     SmallVector<TiledInput> newTiledIns;
@@ -1368,13 +1371,13 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
     // 4. create the new generic op and generic body
     auto newGeneric = cpu::GenericOp::create(
         rewriter, genericOp.getLoc(), forOp.getResultTypes(),
-        /*initVals=*/ValueRange{acc}, newInsValues, newBlockShapes,
-        newTileShapes,
+        /*initVals=*/ValueRange{forOp.getInitArgs()[0]}, newInsValues,
+        newBlockShapes, newTileShapes,
         /*reductionDims=*/{0});
 
     IRMapping mapping;
     Block *newBody = initGenericBody(rewriter, newGeneric, newTiledIns,
-                                     newTileShapes, mapping);
+                                     {accIterArgType}, newTileShapes, mapping);
 
     // 5. wire up body arg mappings
     // Generic tile loop IVs
@@ -1401,70 +1404,8 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
     cpu::YieldOp::create(rewriter, oldYield.getLoc(),
                          mapping.lookup(oldYield.getValues()[0]));
 
-    llvm::errs() << "new generic with cloned body: " << newGeneric << "\n";
-
     // 7. replace old op
-    // rewriter.replaceAllUsesWith(forOp.getResults(), newGeneric.getResults());
-    // rewriter.eraseOp(forOp);
     rewriter.replaceOp(forOp, newGeneric.getResults());
-#if 0
-
-
-    auto aOperandType = cast<RankedTensorType>(dotOp.getA().getType());
-    gpu::BlockedEncodingAttr aOperandEncoding =
-        dyn_cast<gpu::BlockedEncodingAttr>(aOperandType.getEncoding());
-    if (!aOperandEncoding) {
-      auto aDotOperandEncoding =
-          cast<gpu::DotOperandEncodingAttr>(aOperandType.getEncoding());
-      aOperandEncoding =
-          cast<gpu::BlockedEncodingAttr>(aDotOperandEncoding.getParent());
-    }
-
-    auto [blockShape, tileShape] =
-        getBlockAndTileShapes(aOperandType, aOperandEncoding);
-    int32_t kTileShape =
-        blockShape[1]; // use the block shape as the kTile shape. The k block
-                       // shape is the runtime value of K (the for loop upper
-                       // bound)
-    llvm::errs() << "m, k block shape: ";
-    for (auto s : blockShape)
-      llvm::errs() << s << " ";
-    llvm::errs() << "\nm, k tile shape: ";
-    for (auto s : tileShape)
-      llvm::errs() << s << " ";
-    llvm::errs() << "\n";
-
-    // 1. compute the K tiling information and re-create the generic to support
-    // tiling over the K dimension. The new generic will be [K, M, N] tiled
-    rewriter.setInsertionPoint(forOp);
-    auto kSizeLoc = forOp.getUpperBound().getLoc();
-    Value kTileConst = arith::ConstantOp::create(
-        rewriter, kSizeLoc, rewriter.getI32IntegerAttr(kTileShape));
-    Value kSize = arith::MulIOp::create(rewriter, kSizeLoc,
-                                        forOp.getUpperBound(), kTileConst);
-
-    SmallVector<Value> newBlockShapes = {kSize, genericOp.getBlockShape()[0],
-                                         genericOp.getBlockShape()[1]};
-    SmallVector<int32_t> newTileShapes = {
-        kTileShape, genericOp.getTileShape()[0], genericOp.getTileShape()[1]};
-
-    SmallVector<Value> initVals =
-        forOp.getInitArgs(); // TODO: likely have to tile the accumulator?
-
-    auto newGeneric = cpu::GenericOp::create(
-        rewriter, genericOp.getLoc(), genericOp.getResultTypes(), initVals,
-        genericOp.getIns(), newBlockShapes, newTileShapes,
-        /*reductionDims=*/{0});
-    llvm::errs() << "created new generic: " << newGeneric << "\n";
-
-    // 2. clone the old generic body into the new generic. we need to take care to map the induction variable and loop carried dependency, as well as update the K dimension of any tiled operands to use the new tile shape
-
-    Block &genericBody = genericOp.getBody().front();
-
-    IRMapping mapping;
-#endif
-    // assert(false && "todo");
-
     return success();
   }
 };

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -1253,6 +1253,11 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
     if (genericOp.getNumResults() != 1)
       return std::nullopt; // generic must have exactly 1 result (the dot op
                            // result - should we verify that?)
+    // the generic cannot have existing iter args (this will break the pattern
+    // matching below but we should adjust the pattern matcher to handle this
+    // generically)
+    if (genericOp.getNumIterArgs() != 0)
+      return std::nullopt;
 
     // ensure the sole loop carried iter arg is the dot op accumulator
     triton::DotOp dotOp;

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -1392,12 +1392,18 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
       mapping.map(oldBody.getArgument(entry.oldBodyArgPos),
                   newBody->getArgument(newGeneric.getInsArgOffset() + newPos));
 
-    // K loop IV
-    for (auto pos : kIVBodyArgPositions)
-      mapping.map(oldBody.getArgument(pos), newBody->getArgument(0));
-
     // 6. clone body ops
     rewriter.setInsertionPointToStart(newBody);
+
+    // convert loop kIV from global idx to tile idx
+    Value kElemOffset = newBody->getArgument(0);
+    Value kTileIdxConst = arith::ConstantOp::create(
+        rewriter, forOp.getLoc(), rewriter.getI32IntegerAttr(kTileShape));
+    Value kTileIdx =
+        arith::DivSIOp::create(rewriter, forOp.getLoc(), kElemOffset, kTileIdxConst);
+    for (auto pos : kIVBodyArgPositions)
+      mapping.map(oldBody.getArgument(pos), kTileIdx);
+      
     for (Operation &op : oldBody.without_terminator())
       rewriter.clone(op, mapping);
     auto oldYield = cast<cpu::YieldOp>(oldBody.getTerminator());

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -1222,6 +1222,9 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
     // step must be 1
     if (!matchPattern(forOp.getStep(), m_One()))
       return std::nullopt;
+    // loop must be from 0 to numKTiles
+    if (!matchPattern(forOp.getLowerBound(), m_Zero()))
+      return std::nullopt;
 
     auto numIterArgs = forOp.getNumRegionIterArgs();
     if (numIterArgs != 1)
@@ -1241,6 +1244,13 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
     }
     if (!genericOp)
       return std::nullopt;
+
+    // for safety, we can relax these later
+    if (!genericOp.getBody().hasOneBlock())
+      return std::nullopt;
+    if (genericOp.getNumResults() != 1)
+      return std::nullopt; // generic must have exactly 1 result (the dot op
+                           // result - should we verify that?)
 
     // ensure the sole loop carried iter arg is the dot op accumulator
     triton::DotOp dotOp;
@@ -1274,6 +1284,126 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
 
     auto [genericOp, dotOp] = *targetGenericOp;
     llvm::errs() << "candidate for op: " << forOp << "\n";
+
+    // 1. partition inputs, drop existing for loop inputs
+    Value kIV = forOp.getInductionVar();
+    Value acc = forOp.getRegionIterArg(0);
+    Block &oldBody = genericOp.getBody().front();
+    // insArgOffset is the index of the first ins body arg: skips the tile IV
+    // args (one per tileShape dim) and any initVal args.
+    unsigned insArgOffset = genericOp.getInsArgOffset();
+
+    SmallVector<unsigned> kIVBodyArgPositions;
+    unsigned accBodyArgPos = 0;
+    bool foundAcc = false;
+
+    struct KeptInsEntry {
+      unsigned oldBodyArgPos;
+      Value value;
+      SmallVector<int32_t>
+          tileShape; // tiled shape of the body arg; {} for scalars
+    };
+    SmallVector<KeptInsEntry> keptIns;
+
+    for (auto [i, operand] : llvm::enumerate(genericOp.getIns())) {
+      unsigned bodyArgPos = insArgOffset + i;
+      if (operand == kIV) {
+        kIVBodyArgPositions.push_back(bodyArgPos);
+      } else if (operand == acc) {
+        accBodyArgPos = bodyArgPos;
+        foundAcc = true;
+      } else {
+        SmallVector<int32_t> shape;
+        if (auto tensorTy = dyn_cast<RankedTensorType>(
+                oldBody.getArgument(bodyArgPos).getType()))
+          shape = SmallVector<int32_t>(tensorTy.getShape().begin(),
+                                       tensorTy.getShape().end());
+        keptIns.push_back({bodyArgPos, operand, shape});
+      }
+    }
+
+    // sanity: we must have found both the acc and at least one kIV entry
+    if (!foundAcc || kIVBodyArgPositions.empty())
+      return failure();
+
+    // 2. Build new blockShape and tileShape using the A operand to get the K
+    // block size
+    auto aOperandType = cast<RankedTensorType>(dotOp.getA().getType());
+    gpu::BlockedEncodingAttr aOperandEncoding =
+        dyn_cast<gpu::BlockedEncodingAttr>(aOperandType.getEncoding());
+    if (!aOperandEncoding) {
+      auto aDotOperandEncoding =
+          cast<gpu::DotOperandEncodingAttr>(aOperandType.getEncoding());
+      aOperandEncoding =
+          cast<gpu::BlockedEncodingAttr>(aDotOperandEncoding.getParent());
+    }
+
+    auto [blockShape, tileShape] =
+        getBlockAndTileShapes(aOperandType, aOperandEncoding);
+    int32_t kTileShape =
+        blockShape[1]; // use the block shape as the kTile shape. The k block
+                       // shape is the runtime value of K (the for loop upper
+                       // bound)
+
+    rewriter.setInsertionPoint(forOp);
+    auto kSizeLoc = forOp.getUpperBound().getLoc();
+    Value kTileConst = arith::ConstantOp::create(
+        rewriter, kSizeLoc, rewriter.getI32IntegerAttr(kTileShape));
+    Value kSize = arith::MulIOp::create(rewriter, kSizeLoc,
+                                        forOp.getUpperBound(), kTileConst);
+
+    SmallVector<Value> newBlockShapes = {kSize, genericOp.getBlockShape()[0],
+                                         genericOp.getBlockShape()[1]};
+    SmallVector<int32_t> newTileShapes = {
+        kTileShape, genericOp.getTileShape()[0], genericOp.getTileShape()[1]};
+
+    // 3. Build new TiledInput list
+    SmallVector<TiledInput> newTiledIns;
+    for (auto &entry : keptIns)
+      newTiledIns.push_back({entry.value, entry.tileShape});
+    auto newInsValues = llvm::map_to_vector(
+        newTiledIns, [](const TiledInput &ti) { return ti.value; });
+
+    // 4. create the new generic op and generic body
+    auto newGeneric = cpu::GenericOp::create(
+        rewriter, genericOp.getLoc(), forOp.getResultTypes(),
+        /*initVals=*/ValueRange{acc}, newInsValues, newBlockShapes,
+        newTileShapes,
+        /*reductionDims=*/{0});
+
+    IRMapping mapping;
+    Block *newBody = initGenericBody(rewriter, newGeneric, newTiledIns,
+                                     newTileShapes, mapping);
+
+    llvm::errs() << "new generic = " << newGeneric << "\n";
+
+    // 5. wire up body arg mappings
+    // Generic tile loop IVs
+    for (unsigned i = 0; i < genericOp.getNumInductionVars(); i++)
+      mapping.map(oldBody.getArgument(i), newBody->getArgument(i + 1));
+
+    // old acc body arg -> new acc tile iter arg
+    mapping.map(oldBody.getArgument(accBodyArgPos), newGeneric.getIterArg(0));
+
+    // K loop IV
+    for (auto pos : kIVBodyArgPositions)
+      mapping.map(oldBody.getArgument(pos), newBody->getArgument(0));
+
+    // 6. clone body ops
+    rewriter.setInsertionPointToStart(newBody);
+    for (Operation &op : oldBody.without_terminator())
+      rewriter.clone(op, mapping);
+    auto oldYield = cast<cpu::YieldOp>(oldBody.getTerminator());
+    cpu::YieldOp::create(rewriter, oldYield.getLoc(),
+                         mapping.lookup(oldYield.getValues()[0]));
+
+    llvm::errs() << "new generic with cloned body: " << newGeneric << "\n";
+
+    // 7. replace old op
+    rewriter.replaceAllUsesWith(forOp.getResults(), newGeneric.getResults());
+    rewriter.eraseOp(forOp);
+#if 0
+
 
     auto aOperandType = cast<RankedTensorType>(dotOp.getA().getType());
     gpu::BlockedEncodingAttr aOperandEncoding =
@@ -1327,10 +1457,10 @@ struct TileKLoop : mlir::OpRewritePattern<scf::ForOp> {
     Block &genericBody = genericOp.getBody().front();
 
     IRMapping mapping;
+#endif
+    // assert(false && "todo");
 
-    assert(false && "todo");
-
-    return failure();
+    return success();
   }
 };
 

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -120,149 +120,16 @@ public:
                       ArrayRef<Value> results, ArrayRef<Type> resultTypes,
                       unsigned vectorSize);
 
+  // update loop carried iter arg state, scattering to global buffers as
+  // necessary.
   void updateIterArgs(ConversionPatternRewriter &rewriter,
-                      ArrayRef<Value> newIterArgVals) {
-#if 1
-    unsigned totalIterArgs = llvm::count_if(args, [](const ArgInfo &a) {
-      return a.kind == ArgInfo::Kind::IterArg;
-    });
-    assert(newIterArgVals.size() == totalIterArgs &&
-           "expected iter arg update size to match total number of iter args");
-
-    loopIterArgs.clear();
-
-    unsigned scalarIdx = 0, yieldIdx = 0;
-    for (const auto &arg : args) {
-      if (arg.kind == ArgInfo::Kind::IterArg) {
-        Value yieldVal = newIterArgVals[yieldIdx++];
-        if (arg.bufferPtr) {
-          // buffer ptr inter args may be forwarded from the previous loop
-          // level. only update the tile data for iter args that are the result
-          // of a ttc.yield, which will have triton types
-          if (isa<RankedTensorType>(yieldVal.getType())) {
-            Location loc = yieldVal.getLoc();
-
-            auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-#if 0
-          // yield vla is a ptr now, we can drop this entire thing
-          if (isa<RankedTensorType>(yieldVal.getType())) {
-            assert(
-                yieldVal.getDefiningOp() &&
-                "expected triton tensor result iter arg operand to be defined "
-                "by an op");
-            if (auto castedNewIterArgVal = dyn_cast<UnrealizedConversionCastOp>(
-                    yieldVal.getDefiningOp())) {
-              // if the new iter arg val is coming from ttc.yield we need to
-              // extract the llvm type through the unrealized conversion cast
-              // due to the way this pass is layered into the existing llvm
-              // lowering
-              yieldVal = castedNewIterArgVal.getOperand(0);
-            } else {
-              llvm_unreachable("expected iter arg with triton type to be "
-                               "result of unrealized converison cast");
-            }
-          }
-#endif
-
-            auto llvmStruct = cast<LLVM::LLVMStructType>(arg.llvmType);
-            auto castedYieldVal = UnrealizedConversionCastOp::create(
-                                      rewriter, loc, arg.llvmType, yieldVal)
-                                      .getResult(0);
-            for (unsigned j = 0; j < llvmStruct.getBody().size(); ++j) {
-              Value elem =
-                  b.extract_val(llvmStruct.getBody()[j], castedYieldVal, j);
-              Value idx = b.add(iterArgOffset, b.i32_val(j));
-              Value gep =
-                  b.gep(ptr_ty(rewriter.getContext()), llvmStruct.getBody()[j],
-                        arg.bufferPtr, ValueRange{idx});
-              b.store(elem, gep);
-            }
-          }
-          loopIterArgs.push_back(arg.bufferPtr);
-        } else {
-          loopIterArgs.push_back(yieldVal);
-        }
-      }
-    }
-
-#else
-    assert(loopIterArgs.size() == loopIterArgsToArgInfo.size());
-    for (auto [idx, argInfoIdx] : loopIterArgsToArgInfo) {
-      auto &argInfo = args[argInfoIdx];
-      assert(argInfo.kind == ArgInfo::Kind::IterArg);
-      if (Value ptr = argInfo.bufferPtr) {
-        llvm::errs() << "new iter arg val: " << newIterArgVals[idx] << "\n";
-        llvm::errs() << "old iter arg val: " << loopIterArgs[idx] << "\n";
-        Value newIterArgVal = newIterArgVals[idx];
-        Location loc = newIterArgVal.getLoc();
-
-        auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-        if (isa<RankedTensorType>(newIterArgVal.getType())) {
-          assert(newIterArgVal.getDefiningOp() &&
-                 "expected triton tensor result iter arg operand to be defined "
-                 "by an op");
-          if (auto castedNewIterArgVal = dyn_cast<UnrealizedConversionCastOp>(
-                  newIterArgVal.getDefiningOp())) {
-            // if the new iter arg val is coming from ttc.yield we need to
-            // extract the llvm type through the unrealized conversion cast due
-            // to the way this pass is layered into the existing llvm lowering
-            newIterArgVal = castedNewIterArgVal.getOperand(0);
-          }
-        }
-
-        auto llvmStruct = cast<LLVM::LLVMStructType>(newIterArgVal.getType());
-        for (unsigned j = 0; j < llvmStruct.getBody().size(); ++j) {
-          Value elem = b.extract_val(llvmStruct.getBody()[j], newIterArgVal, j);
-          Value idx = b.add(flatOffset, b.i32_val(j));
-          Value gep = b.gep(ptr_ty(rewriter.getContext()),
-                            llvmStruct.getBody()[j], ptr, ValueRange{idx});
-          b.store(elem, gep);
-        }
-      } else {
-        // this will probably be overwritten when we next compute block
-        // arguments, but that's ok -- or is it? do we need to get the next tile
-        // for the iter arg here?
-        loopIterArgs.push_back(newIterArgVals[idx]);
-      }
-    }
-#endif
-  }
+                      ArrayRef<Value> newIterArgVals);
 
   SmallVector<Value> getIterArgVals() const { return loopIterArgs; }
 
   SmallVector<Value> getResults() const {
     SmallVector<Value> ret;
-
-#if 1
-#if 1
     ret.append(loopIterArgs.begin(), loopIterArgs.end());
-#else
-    // TODO: push back either iter args or buffer ptrs? or should we reload the
-    // entire buffer ptr into a struct and return that? are downstream users
-    // guarnateed to be generic ops? (in this case they are)
-    unsigned scalarIdx = 0;
-    for (const auto &arg : args) {
-      if (arg.kind == ArgInfo::Kind::IterArg) {
-        if (arg.bufferPtr) {
-          ret.push_back(arg.bufferPtr);
-        } else {
-          ret.push_back(loopIterArgs[scalarIdx++]);
-        }
-      }
-    }
-#endif
-#else
-    for (auto [idx, argInfoIdx] : loopIterArgsToArgInfo) {
-      auto &argInfo = args[argInfoIdx];
-      if (argInfo.bufferPtr) {
-        ret.push_back(argInfo.bufferPtr);
-      } else {
-        ret.push_back(loopIterArgs[idx]);
-      }
-    }
-#endif
     ret.append(materializedResults.begin(), materializedResults.end());
     return ret;
   }
@@ -323,26 +190,9 @@ LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset,
         }
 
         loopIterArgs.push_back(globalPtr);
-#if 0
-        // now re-load the first tile from the global buffer so the iter arg can
-        // be used in the loop body. subsequent tiles are loaded by
-        // updateIterArgs
-        auto tileStructTy = cast<LLVM::LLVMStructType>(arg.llvmType);
-        Value tileStruct = LLVM::UndefOp::create(rewriter, loc, tileStructTy);
-
-        for (unsigned j = 0; j < tileStructTy.getBody().size(); ++j) {
-          Value gep = b.gep(LLVM::LLVMPointerType::get(rewriter.getContext()),
-                            elemTy, globalPtr, b.i32_val(j));
-          Value elem = b.load(elemTy, gep);
-          tileStruct = b.insert_val(tileStructTy, tileStruct, elem, j);
-        }
-        // replace the loop iter arg with the current tile loaded from memory
-        tensorIterArgs.push_back(tileStruct);
-#endif
       } else {
         loopIterArgs.push_back(arg.operand);
       }
-      // loopIterArgsToArgInfo[loopIterArgs.size() - 1] = idx;
     }
   }
 
@@ -382,7 +232,6 @@ LoopHelper::getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
   SmallVector<Value> blockArgs = {tileOffsets.begin(), tileOffsets.end()};
 
   // iter args
-#if 1
   unsigned scalarIdx = 0;
   for (const auto &arg : args) {
     if (arg.kind == ArgInfo::Kind::IterArg) {
@@ -408,31 +257,6 @@ LoopHelper::getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
       }
     }
   }
-#else
-  assert(loopIterArgs.size() == loopIterArgsToArgInfo.size());
-  for (auto [idx, argInfoIdx] : loopIterArgsToArgInfo) {
-    auto &argInfo = args[argInfoIdx];
-    assert(argInfo.kind == ArgInfo::Kind::IterArg);
-    if (argInfo.bufferPtr) {
-      Location loc = argInfo.operand.getLoc();
-      auto tileStructTy = cast<LLVM::LLVMStructType>(argInfo.llvmType);
-      Type elemTy = tileStructTy.getBody()[0];
-      Value tileStruct = LLVM::UndefOp::create(rewriter, loc, tileStructTy);
-      auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-      for (unsigned j = 0; j < tileStructTy.getBody().size(); ++j) {
-        Value globalIdx = b.add(flatOffset, b.i32_val(j));
-        Value gep = b.gep(LLVM::LLVMPointerType::get(rewriter.getContext()),
-                          elemTy, argInfo.bufferPtr, ValueRange{globalIdx});
-        Value elem = b.load(elemTy, gep);
-        tileStruct = b.insert_val(tileStructTy, tileStruct, elem, j);
-      }
-      // replace the loop iter arg with the current tile loaded from memory
-      loopIterArgs[idx] = tileStruct;
-    }
-    blockArgs.push_back(loopIterArgs[idx]);
-  }
-#endif
 
   // Add ins args
   for (const auto &argInfo : args) {
@@ -529,6 +353,49 @@ void LoopHelper::scatterResults(ConversionPatternRewriter &rewriter,
       Value gep =
           b.gep(ptr_ty(rewriter.getContext()), elemTy, ptr, ValueRange{idx});
       b.store(elem, gep);
+    }
+  }
+}
+
+void LoopHelper::updateIterArgs(ConversionPatternRewriter &rewriter,
+                                ArrayRef<Value> newIterArgVals) {
+  unsigned totalIterArgs = llvm::count_if(
+      args, [](const ArgInfo &a) { return a.kind == ArgInfo::Kind::IterArg; });
+  assert(newIterArgVals.size() == totalIterArgs &&
+         "expected iter arg update size to match total number of iter args");
+
+  loopIterArgs.clear();
+
+  unsigned scalarIdx = 0, yieldIdx = 0;
+  for (const auto &arg : args) {
+    if (arg.kind == ArgInfo::Kind::IterArg) {
+      Value yieldVal = newIterArgVals[yieldIdx++];
+      if (arg.bufferPtr) {
+        // buffer ptr inter args may be forwarded from the previous loop
+        // level. only update the tile data for iter args that are the result
+        // of a ttc.yield, which will have triton types
+        if (isa<RankedTensorType>(yieldVal.getType())) {
+          Location loc = yieldVal.getLoc();
+
+          auto b = TritonLLVMOpBuilder(loc, rewriter);
+          auto llvmStruct = cast<LLVM::LLVMStructType>(arg.llvmType);
+          auto castedYieldVal = UnrealizedConversionCastOp::create(
+                                    rewriter, loc, arg.llvmType, yieldVal)
+                                    .getResult(0);
+          for (unsigned j = 0; j < llvmStruct.getBody().size(); ++j) {
+            Value elem =
+                b.extract_val(llvmStruct.getBody()[j], castedYieldVal, j);
+            Value idx = b.add(iterArgOffset, b.i32_val(j));
+            Value gep =
+                b.gep(ptr_ty(rewriter.getContext()), llvmStruct.getBody()[j],
+                      arg.bufferPtr, ValueRange{idx});
+            b.store(elem, gep);
+          }
+        }
+        loopIterArgs.push_back(arg.bufferPtr);
+      } else {
+        loopIterArgs.push_back(yieldVal);
+      }
     }
   }
 }

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -83,8 +83,8 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const ArgInfo &a) {
 
 class LoopHelper {
 public:
-  LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset, Value iterArgOffset,
-             cpu::GenericOp generic, const TypeConverter *typeConverter,
+  LoopHelper(ArrayRef<ArgInfo> args, cpu::GenericOp generic,
+             const TypeConverter *typeConverter,
              ConversionPatternRewriter &rewriter);
 
   SmallVector<Value> getEntryArgs() {
@@ -151,12 +151,15 @@ private:
   SmallVector<int32_t> reductionDims;
 };
 
-LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset,
-                       Value iterArgOffset, cpu::GenericOp generic,
+LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, cpu::GenericOp generic,
                        const TypeConverter *typeConverter,
                        ConversionPatternRewriter &rewriter)
-    : args(args.begin(), args.end()), flatOffset(flatOffset),
-      iterArgOffset(flatOffset), reductionDims(generic.getReductionDims()) {
+    : args(args.begin(), args.end()),
+      reductionDims(generic.getReductionDims()) {
+
+  auto gb = TritonLLVMOpBuilder(generic.getLoc(), rewriter);
+  flatOffset = gb.i32_val(0);
+  iterArgOffset = gb.i32_val(0);
 
   for (auto [idx, arg] : llvm::enumerate(this->args)) {
     if (arg.kind == ArgInfo::Kind::IterArg) {
@@ -414,6 +417,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     // find the generic op producing this tensor
     auto result = dyn_cast<OpResult>(op.getIns()[opIdx]);
     if (!result)
+      return {};
+    if (!isa<RankedTensorType>(result.getType()))
       return {};
     auto defGeneric = dyn_cast<cpu::GenericOp>(result.getOwner());
     if (!defGeneric)
@@ -827,10 +832,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       assert(blockShape.size() == tileShape.size() &&
              "expected blockShape and tileShape to have "
              "the same rank");
-      auto b = TritonLLVMOpBuilder(loc, rewriter);
-      LoopHelper helper(argInfos, /*flatOffset=*/b.i32_val(0),
-                        /*iterArgOffset=*/b.i32_val(0), op, getTypeConverter(),
-                        rewriter);
+      LoopHelper helper(argInfos, op, getTypeConverter(), rewriter);
       emitUnrolled(op, helper, rewriter, numChunks, vectorSize, blockShape,
                    tileShape);
       results = helper.getResults();
@@ -848,10 +850,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       assert(allUsersAreGeneric && "expected all generic op users to also be "
                                    "generic ops on dynamic path");
 
-      auto b = TritonLLVMOpBuilder(loc, rewriter);
-      LoopHelper helper(argInfos, /*flatOffset=*/b.i32_val(0),
-                        /*iterArgOffset=*/b.i32_val(0), op, getTypeConverter(),
-                        rewriter);
+      LoopHelper helper(argInfos, op, getTypeConverter(), rewriter);
       SmallVector<Value> blockShapeVals(op.getBlockShape().begin(),
                                         op.getBlockShape().end());
       emitNestedLoops(op, helper, rewriter, /*dim=*/0, blockShapeVals,

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -117,9 +117,52 @@ public:
 
   void updateIterArgs(ConversionPatternRewriter &rewriter,
                       ArrayRef<Value> newIterArgVals) {
-    assert(newIterArgVals.size() == loopIterArgs.size());
-    // TODO: scatter updated iter arg values into global buffers
+#if 1
+    unsigned totalIterArgs = llvm::count_if(args, [](const ArgInfo &a) {
+      return a.kind == ArgInfo::Kind::IterArg;
+    });
+    assert(newIterArgVals.size() == totalIterArgs &&
+           "expected iter arg update size to match total number of iter args");
 
+    unsigned scalarIdx = 0, yieldIdx = 0;
+    for (const auto &arg : args) {
+      if (arg.kind == ArgInfo::Kind::IterArg) {
+        Value yieldVal = newIterArgVals[yieldIdx++];
+        if (arg.bufferPtr) {
+          Location loc = yieldVal.getLoc();
+
+          auto b = TritonLLVMOpBuilder(loc, rewriter);
+          if (isa<RankedTensorType>(yieldVal.getType())) {
+            assert(
+                yieldVal.getDefiningOp() &&
+                "expected triton tensor result iter arg operand to be defined "
+                "by an op");
+            if (auto castedNewIterArgVal = dyn_cast<UnrealizedConversionCastOp>(
+                    yieldVal.getDefiningOp())) {
+              // if the new iter arg val is coming from ttc.yield we need to
+              // extract the llvm type through the unrealized conversion cast
+              // due to the way this pass is layered into the existing llvm
+              // lowering
+              yieldVal = castedNewIterArgVal.getOperand(0);
+            }
+
+            auto llvmStruct = cast<LLVM::LLVMStructType>(yieldVal.getType());
+            for (unsigned j = 0; j < llvmStruct.getBody().size(); ++j) {
+              Value elem = b.extract_val(llvmStruct.getBody()[j], yieldVal, j);
+              Value idx = b.add(flatOffset, b.i32_val(j));
+              Value gep =
+                  b.gep(ptr_ty(rewriter.getContext()), llvmStruct.getBody()[j],
+                        arg.bufferPtr, ValueRange{idx});
+              b.store(elem, gep);
+            }
+          }
+        } else {
+          loopIterArgs[scalarIdx++] = yieldVal;
+        }
+      }
+    }
+
+#else
     assert(loopIterArgs.size() == loopIterArgsToArgInfo.size());
     for (auto [idx, argInfoIdx] : loopIterArgsToArgInfo) {
       auto &argInfo = args[argInfoIdx];
@@ -153,15 +196,14 @@ public:
                             llvmStruct.getBody()[j], ptr, ValueRange{idx});
           b.store(elem, gep);
         }
-
-        loopIterArgs[idx] = newIterArgVal;
       } else {
         // this will probably be overwritten when we next compute block
         // arguments, but that's ok -- or is it? do we need to get the next tile
         // for the iter arg here?
-        loopIterArgs[idx] = newIterArgVals[idx];
+        loopIterArgs.push_back(newIterArgVals[idx]);
       }
     }
+#endif
   }
 
   SmallVector<Value> getIterArgVals() const { return loopIterArgs; }
@@ -169,6 +211,21 @@ public:
   SmallVector<Value> getResults() const {
     SmallVector<Value> ret;
 
+#if 1
+    // TODO: push back either iter args or buffer ptrs? or should we reload the
+    // entire buffer ptr into a struct and return that? are downstream users
+    // guarnateed to be generic ops? (in this case they are)
+    unsigned scalarIdx = 0;
+    for (const auto &arg : args) {
+      if (arg.kind == ArgInfo::Kind::IterArg) {
+        if (arg.bufferPtr) {
+          ret.push_back(arg.bufferPtr);
+        } else {
+          ret.push_back(loopIterArgs[scalarIdx++]);
+        }
+      }
+    }
+#else
     for (auto [idx, argInfoIdx] : loopIterArgsToArgInfo) {
       auto &argInfo = args[argInfoIdx];
       if (argInfo.bufferPtr) {
@@ -177,7 +234,7 @@ public:
         ret.push_back(loopIterArgs[idx]);
       }
     }
-
+#endif
     ret.append(materializedResults.begin(), materializedResults.end());
     return ret;
   }
@@ -185,7 +242,11 @@ public:
 private:
   SmallVector<ArgInfo> args;
   SmallVector<Value> loopIterArgs;
-  DenseMap<unsigned, unsigned> loopIterArgsToArgInfo;
+
+  SmallVector<Value>
+      tensorIterArgs; // remove? this is being stored in the args list
+
+  // DenseMap<unsigned, unsigned> loopIterArgsToArgInfo;
 
   SmallVector<Value> materializedResults;
   SmallVector<Type> materializedResultElementTypes;
@@ -231,6 +292,8 @@ LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset,
           b.store(elem, gep);
         }
 
+        tensorIterArgs.push_back(globalPtr);
+#if 0
         // now re-load the first tile from the global buffer so the iter arg can
         // be used in the loop body. subsequent tiles are loaded by
         // updateIterArgs
@@ -244,11 +307,12 @@ LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset,
           tileStruct = b.insert_val(tileStructTy, tileStruct, elem, j);
         }
         // replace the loop iter arg with the current tile loaded from memory
-        loopIterArgs.push_back(tileStruct);
+        tensorIterArgs.push_back(tileStruct);
+#endif
       } else {
         loopIterArgs.push_back(arg.operand);
       }
-      loopIterArgsToArgInfo[loopIterArgs.size() - 1] = idx;
+      // loopIterArgsToArgInfo[loopIterArgs.size() - 1] = idx;
     }
   }
 
@@ -289,7 +353,30 @@ LoopHelper::getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
 
   // iter args
 #if 1
-  blockArgs.append(loopIterArgs.begin(), loopIterArgs.end());
+  unsigned scalarIdx = 0;
+  for (const auto &arg : args) {
+    if (arg.kind == ArgInfo::Kind::IterArg) {
+      if (arg.bufferPtr) {
+        // load this tiles elements from the global buffer
+        auto tileStructTy = cast<LLVM::LLVMStructType>(arg.llvmType);
+        Type elemTy = tileStructTy.getBody()[0];
+        Value tileStruct =
+            LLVM::UndefOp::create(rewriter, arg.operand.getLoc(), tileStructTy);
+        auto b = TritonLLVMOpBuilder(arg.operand.getLoc(), rewriter);
+
+        for (unsigned j = 0; j < tileStructTy.getBody().size(); ++j) {
+          Value globalIdx = b.add(flatOffset, b.i32_val(j));
+          Value gep = b.gep(LLVM::LLVMPointerType::get(rewriter.getContext()),
+                            elemTy, arg.bufferPtr, ValueRange{globalIdx});
+          Value elem = b.load(elemTy, gep);
+          tileStruct = b.insert_val(tileStructTy, tileStruct, elem, j);
+        }
+        blockArgs.push_back(tileStruct);
+      } else {
+        blockArgs.push_back(loopIterArgs[scalarIdx++]);
+      }
+    }
+  }
 #else
   assert(loopIterArgs.size() == loopIterArgsToArgInfo.size());
   for (auto [idx, argInfoIdx] : loopIterArgsToArgInfo) {

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -124,14 +124,23 @@ public:
     assert(newIterArgVals.size() == totalIterArgs &&
            "expected iter arg update size to match total number of iter args");
 
+    loopIterArgs.clear();
+
     unsigned scalarIdx = 0, yieldIdx = 0;
     for (const auto &arg : args) {
       if (arg.kind == ArgInfo::Kind::IterArg) {
         Value yieldVal = newIterArgVals[yieldIdx++];
         if (arg.bufferPtr) {
-          Location loc = yieldVal.getLoc();
+          // buffer ptr inter args may be forwarded from the previous loop
+          // level. only update the tile data for iter args that are the result
+          // of a ttc.yield, which will have triton types
+          if (isa<RankedTensorType>(yieldVal.getType())) {
+            Location loc = yieldVal.getLoc();
 
-          auto b = TritonLLVMOpBuilder(loc, rewriter);
+            auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+#if 0
+          // yield vla is a ptr now, we can drop this entire thing
           if (isa<RankedTensorType>(yieldVal.getType())) {
             assert(
                 yieldVal.getDefiningOp() &&
@@ -144,11 +153,20 @@ public:
               // due to the way this pass is layered into the existing llvm
               // lowering
               yieldVal = castedNewIterArgVal.getOperand(0);
+            } else {
+              llvm_unreachable("expected iter arg with triton type to be "
+                               "result of unrealized converison cast");
             }
+          }
+#endif
 
-            auto llvmStruct = cast<LLVM::LLVMStructType>(yieldVal.getType());
+            auto llvmStruct = cast<LLVM::LLVMStructType>(arg.llvmType);
+            auto castedYieldVal = UnrealizedConversionCastOp::create(
+                                      rewriter, loc, arg.llvmType, yieldVal)
+                                      .getResult(0);
             for (unsigned j = 0; j < llvmStruct.getBody().size(); ++j) {
-              Value elem = b.extract_val(llvmStruct.getBody()[j], yieldVal, j);
+              Value elem =
+                  b.extract_val(llvmStruct.getBody()[j], castedYieldVal, j);
               Value idx = b.add(flatOffset, b.i32_val(j));
               Value gep =
                   b.gep(ptr_ty(rewriter.getContext()), llvmStruct.getBody()[j],
@@ -156,8 +174,9 @@ public:
               b.store(elem, gep);
             }
           }
+          loopIterArgs.push_back(arg.bufferPtr);
         } else {
-          loopIterArgs[scalarIdx++] = yieldVal;
+          loopIterArgs.push_back(yieldVal);
         }
       }
     }
@@ -212,6 +231,9 @@ public:
     SmallVector<Value> ret;
 
 #if 1
+#if 1
+    ret.append(loopIterArgs.begin(), loopIterArgs.end());
+#else
     // TODO: push back either iter args or buffer ptrs? or should we reload the
     // entire buffer ptr into a struct and return that? are downstream users
     // guarnateed to be generic ops? (in this case they are)
@@ -225,6 +247,7 @@ public:
         }
       }
     }
+#endif
 #else
     for (auto [idx, argInfoIdx] : loopIterArgsToArgInfo) {
       auto &argInfo = args[argInfoIdx];
@@ -292,7 +315,7 @@ LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset,
           b.store(elem, gep);
         }
 
-        tensorIterArgs.push_back(globalPtr);
+        loopIterArgs.push_back(globalPtr);
 #if 0
         // now re-load the first tile from the global buffer so the iter arg can
         // be used in the loop body. subsequent tiles are loaded by
@@ -356,6 +379,7 @@ LoopHelper::getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
   unsigned scalarIdx = 0;
   for (const auto &arg : args) {
     if (arg.kind == ArgInfo::Kind::IterArg) {
+      unsigned crtIndex = scalarIdx++;
       if (arg.bufferPtr) {
         // load this tiles elements from the global buffer
         auto tileStructTy = cast<LLVM::LLVMStructType>(arg.llvmType);
@@ -373,7 +397,7 @@ LoopHelper::getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
         }
         blockArgs.push_back(tileStruct);
       } else {
-        blockArgs.push_back(loopIterArgs[scalarIdx++]);
+        blockArgs.push_back(loopIterArgs[crtIndex]);
       }
     }
   }

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -50,8 +50,8 @@ struct ArgInfo {
   enum class Kind { IV, IterArg, Ins };
 
   ArgInfo(Kind k) : kind(k) {}
-  ArgInfo(Kind k, Type tritonType, Type llvmType)
-      : kind(k), tritonType(tritonType), llvmType(llvmType) {}
+  ArgInfo(Kind k, Type tritonType, Type llvmType, Value operand)
+      : kind(k), tritonType(tritonType), llvmType(llvmType), operand(operand) {}
 
   Kind kind;
   Type tritonType;
@@ -83,8 +83,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const ArgInfo &a) {
 
 class LoopHelper {
 public:
-  LoopHelper(ArrayRef<ArgInfo> args, ArrayRef<Value> loopIterArgs,
-             Value flatOffset, cpu::GenericOp generic,
+  LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset, cpu::GenericOp generic,
              const TypeConverter *typeConverter,
              ConversionPatternRewriter &rewriter);
 
@@ -116,16 +115,66 @@ public:
                       ArrayRef<Value> results, ArrayRef<Type> resultTypes,
                       unsigned vectorSize);
 
-  void updateIterArgs(ArrayRef<Value> newIterArgVals) {
+  void updateIterArgs(ConversionPatternRewriter &rewriter,
+                      ArrayRef<Value> newIterArgVals) {
     assert(newIterArgVals.size() == loopIterArgs.size());
-    for (auto [i, newVal] : llvm::enumerate(newIterArgVals))
-      loopIterArgs[i] = newVal;
+    // TODO: scatter updated iter arg values into global buffers
+
+    assert(loopIterArgs.size() == loopIterArgsToArgInfo.size());
+    for (auto [idx, argInfoIdx] : loopIterArgsToArgInfo) {
+      auto &argInfo = args[argInfoIdx];
+      assert(argInfo.kind == ArgInfo::Kind::IterArg);
+      if (Value ptr = argInfo.bufferPtr) {
+        llvm::errs() << "new iter arg val: " << newIterArgVals[idx] << "\n";
+        llvm::errs() << "old iter arg val: " << loopIterArgs[idx] << "\n";
+        Value newIterArgVal = newIterArgVals[idx];
+        Location loc = newIterArgVal.getLoc();
+
+        auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+        if (isa<RankedTensorType>(newIterArgVal.getType())) {
+          assert(newIterArgVal.getDefiningOp() &&
+                 "expected triton tensor result iter arg operand to be defined "
+                 "by an op");
+          if (auto castedNewIterArgVal = dyn_cast<UnrealizedConversionCastOp>(
+                  newIterArgVal.getDefiningOp())) {
+            // if the new iter arg val is coming from ttc.yield we need to
+            // extract the llvm type through the unrealized conversion cast due
+            // to the way this pass is layered into the existing llvm lowering
+            newIterArgVal = castedNewIterArgVal.getOperand(0);
+          }
+        }
+
+        auto llvmStruct = cast<LLVM::LLVMStructType>(newIterArgVal.getType());
+        for (unsigned j = 0; j < llvmStruct.getBody().size(); ++j) {
+          Value elem = b.extract_val(llvmStruct.getBody()[j], newIterArgVal, j);
+          Value idx = b.add(flatOffset, b.i32_val(j));
+          Value gep = b.gep(ptr_ty(rewriter.getContext()),
+                            llvmStruct.getBody()[j], ptr, ValueRange{idx});
+          b.store(elem, gep);
+        }
+      }
+      // this will probably be overwritten when we next compute block arguments,
+      // but that's ok -- or is it? do we need to get the next tile for the iter
+      // arg here?
+      loopIterArgs[idx] = newIterArgVals[idx];
+    }
   }
 
   SmallVector<Value> getIterArgVals() const { return loopIterArgs; }
 
   SmallVector<Value> getResults() const {
-    SmallVector<Value> ret(loopIterArgs.begin(), loopIterArgs.end());
+    SmallVector<Value> ret;
+
+    for (auto [idx, argInfoIdx] : loopIterArgsToArgInfo) {
+      auto &argInfo = args[argInfoIdx];
+      if (argInfo.bufferPtr) {
+        ret.push_back(argInfo.bufferPtr);
+      } else {
+        ret.push_back(loopIterArgs[idx]);
+      }
+    }
+
     ret.append(materializedResults.begin(), materializedResults.end());
     return ret;
   }
@@ -133,6 +182,7 @@ public:
 private:
   SmallVector<ArgInfo> args;
   SmallVector<Value> loopIterArgs;
+  DenseMap<unsigned, unsigned> loopIterArgsToArgInfo;
 
   SmallVector<Value> materializedResults;
   SmallVector<Type> materializedResultElementTypes;
@@ -141,13 +191,63 @@ private:
   Value flatOffset;
 };
 
-LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, ArrayRef<Value> loopIterArgs,
-                       Value flatOffset, cpu::GenericOp generic,
+LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset,
+                       cpu::GenericOp generic,
                        const TypeConverter *typeConverter,
                        ConversionPatternRewriter &rewriter)
-    : args(args.begin(), args.end()),
-      loopIterArgs(loopIterArgs.begin(), loopIterArgs.end()),
-      flatOffset(flatOffset) {
+    : args(args.begin(), args.end()), flatOffset(flatOffset) {
+
+  for (auto [idx, arg] : llvm::enumerate(this->args)) {
+    if (arg.kind == ArgInfo::Kind::IterArg) {
+      if (auto tileTensorTy = dyn_cast<RankedTensorType>(arg.tritonType)) {
+        Type elemTy = typeConverter->convertType(tileTensorTy.getElementType());
+
+        Location loc = arg.operand.getLoc();
+        // allocate a global buffer for this iter arg
+        auto tensorTy = cast<RankedTensorType>(arg.operand.getType());
+        int64_t tensorElems = std::accumulate(tensorTy.getShape().begin(),
+                                              tensorTy.getShape().end(),
+                                              int64_t{1}, std::multiplies<>());
+
+        Value globalPtr = allocateGlobalBuffer(
+            rewriter, loc, elemTy, tensorElems, loopIterArgs.size(), generic);
+        this->args[idx].bufferPtr = globalPtr;
+
+        // copy the init value
+        auto b = TritonLLVMOpBuilder(loc, rewriter);
+        assert(arg.operand.getDefiningOp() &&
+               "expected iter arg operand to be defined by an op");
+        auto castedInitOp =
+            cast<UnrealizedConversionCastOp>(arg.operand.getDefiningOp());
+        auto initVal = castedInitOp.getOperand(0);
+        auto initStructTy = cast<LLVM::LLVMStructType>(initVal.getType());
+        for (unsigned i = 0; i < initStructTy.getBody().size(); ++i) {
+          Value elem = b.extract_val(initStructTy.getBody()[i], initVal, i);
+          Value gep = b.gep(LLVM::LLVMPointerType::get(rewriter.getContext()),
+                            elemTy, globalPtr, b.i32_val(i));
+          b.store(elem, gep);
+        }
+
+        // now re-load the first tile from the global buffer so the iter arg can
+        // be used in the loop body. subsequent tiles are loaded by
+        // updateIterArgs
+        auto tileStructTy = cast<LLVM::LLVMStructType>(arg.llvmType);
+        Value tileStruct = LLVM::UndefOp::create(rewriter, loc, tileStructTy);
+
+        for (unsigned j = 0; j < tileStructTy.getBody().size(); ++j) {
+          Value gep = b.gep(LLVM::LLVMPointerType::get(rewriter.getContext()),
+                            elemTy, globalPtr, b.i32_val(j));
+          Value elem = b.load(elemTy, gep);
+          tileStruct = b.insert_val(tileStructTy, tileStruct, elem, j);
+        }
+        // replace the loop iter arg with the current tile loaded from memory
+        loopIterArgs.push_back(tileStruct);
+      } else {
+        loopIterArgs.push_back(arg.operand);
+      }
+      loopIterArgsToArgInfo[loopIterArgs.size() - 1] = idx;
+    }
+  }
 
   // Create temporary buffers in thread local global memory for materialized
   // results. This avoids loop-carried <blockSize x elemTy> phi nodes
@@ -171,7 +271,8 @@ LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, ArrayRef<Value> loopIterArgs,
 
     Value globalPtr = allocateGlobalBuffer(
         rewriter, generic.getResult(i + generic.getNumIterArgs()).getLoc(),
-        elemTy, tensorElems, materializedResults.size(), generic);
+        elemTy, tensorElems, materializedResults.size() + loopIterArgs.size(),
+        generic);
     materializedResults.push_back(globalPtr);
   }
 }
@@ -184,7 +285,33 @@ LoopHelper::getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
   SmallVector<Value> blockArgs = {tileOffsets.begin(), tileOffsets.end()};
 
   // iter args
+#if 1
   blockArgs.append(loopIterArgs.begin(), loopIterArgs.end());
+#else
+  assert(loopIterArgs.size() == loopIterArgsToArgInfo.size());
+  for (auto [idx, argInfoIdx] : loopIterArgsToArgInfo) {
+    auto &argInfo = args[argInfoIdx];
+    assert(argInfo.kind == ArgInfo::Kind::IterArg);
+    if (argInfo.bufferPtr) {
+      Location loc = argInfo.operand.getLoc();
+      auto tileStructTy = cast<LLVM::LLVMStructType>(argInfo.llvmType);
+      Type elemTy = tileStructTy.getBody()[0];
+      Value tileStruct = LLVM::UndefOp::create(rewriter, loc, tileStructTy);
+      auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+      for (unsigned j = 0; j < tileStructTy.getBody().size(); ++j) {
+        Value globalIdx = b.add(flatOffset, b.i32_val(j));
+        Value gep = b.gep(LLVM::LLVMPointerType::get(rewriter.getContext()),
+                          elemTy, argInfo.bufferPtr, ValueRange{globalIdx});
+        Value elem = b.load(elemTy, gep);
+        tileStruct = b.insert_val(tileStructTy, tileStruct, elem, j);
+      }
+      // replace the loop iter arg with the current tile loaded from memory
+      loopIterArgs[idx] = tileStruct;
+    }
+    blockArgs.push_back(loopIterArgs[idx]);
+  }
+#endif
 
   // Add ins args
   for (const auto &argInfo : args) {
@@ -303,9 +430,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     auto defGeneric = dyn_cast<cpu::GenericOp>(result.getOwner());
     if (!defGeneric)
       return {};
-    // TODO: overly defensive?
-    if (result.getResultNumber() < defGeneric.getNumIterArgs())
-      return {};
 
     assert(isa<LLVM::LLVMStructType>(llvmArg.getType()) &&
            "expected tensor value adaptor type to be a struct type");
@@ -327,18 +451,17 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
     // handle loop induction vars first
     for (unsigned i = 0; i < tileShape.size(); i++) {
-      args.emplace_back(ArgInfo(ArgInfo::Kind::IV, nullptr, i32_ty));
+      args.emplace_back(ArgInfo(ArgInfo::Kind::IV, nullptr, i32_ty, nullptr));
     }
 
     for (unsigned i = 0; i < op.getNumIterArgs(); i++) {
       Type tritonType = op.getIterArg(i).getType();
-      assert(!isa<RankedTensorType>(tritonType) &&
-             "tensor type iter args not yet supported");
       Type llvmType = getTypeConverter()->convertType(tritonType);
 
       // TODO: create alloca backed buffers corresponding to init arg and copy
       // init arg in if we have a tensor type.
-      args.emplace_back(ArgInfo(ArgInfo::Kind::IterArg, tritonType, llvmType));
+      args.emplace_back(ArgInfo(ArgInfo::Kind::IterArg, tritonType, llvmType,
+                                op.getInitVals()[i]));
     }
 
     Block *body = &op.getBody().front();
@@ -451,7 +574,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
       auto [newIterArgVals, loopTiles] =
           cloneTileBody(op, rewriter, chunkedArgs);
-      helper.updateIterArgs(newIterArgVals);
+      helper.updateIterArgs(rewriter, newIterArgVals);
       SmallVector<Type> resultTypes =
           llvm::map_to_vector(loopTiles, [&](Value tile) {
             return getTypeConverter()->convertType(tile.getType());
@@ -576,7 +699,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
         SmallVector<Value> newIterArgVals(yieldOp.getValues().begin(),
                                           yieldOp.getValues().begin() +
                                               numIterArgs);
-        helper.updateIterArgs(newIterArgVals);
+        helper.updateIterArgs(rewriter, newIterArgVals);
 
         // scatter non-iter-arg tensor tiles
         SmallVector<Value> loopTiles(yieldOp.getValues().begin() + numIterArgs,
@@ -614,7 +737,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           SmallVector<Value> innerIterArgVals(currentCarried.begin(),
                                               currentCarried.end());
 
-          helper.updateIterArgs(innerIterArgVals);
+          helper.updateIterArgs(rewriter, innerIterArgVals);
           emitNestedLoops(op, helper, rewriter, dim + 1, blockShape, tileShape,
                           vectorSize, afterBlock);
 
@@ -622,7 +745,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           return helper.getIterArgVals();
         });
 
-    helper.updateIterArgs(finalCarried);
+    helper.updateIterArgs(rewriter, finalCarried);
   }
 
   LogicalResult
@@ -669,10 +792,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
           return argInfo.requiresMaterialization();
         });
 
-    // Iter arg values start from init_vals and are updated tile-by-tile.
-    SmallVector<Value> iterArgVals(adaptor.getInitVals().begin(),
-                                   adaptor.getInitVals().end());
-
     int numChunks = -1;
     SmallVector<int32_t> blockShape;
     for (auto [i, dim] : llvm::enumerate(op.getBlockShape())) {
@@ -704,7 +823,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
              "expected blockShape and tileShape to have "
              "the same rank");
       auto b = TritonLLVMOpBuilder(loc, rewriter);
-      LoopHelper helper(argInfos, iterArgVals, /*flatOffset=*/b.i32_val(0), op,
+      LoopHelper helper(argInfos, /*flatOffset=*/b.i32_val(0), op,
                         getTypeConverter(), rewriter);
       emitUnrolled(op, helper, rewriter, numChunks, vectorSize, blockShape,
                    tileShape);
@@ -724,7 +843,7 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                                    "generic ops on dynamic path");
 
       auto b = TritonLLVMOpBuilder(loc, rewriter);
-      LoopHelper helper(argInfos, iterArgVals, /*flatOffset=*/b.i32_val(0), op,
+      LoopHelper helper(argInfos, /*flatOffset=*/b.i32_val(0), op,
                         getTypeConverter(), rewriter);
       SmallVector<Value> blockShapeVals(op.getBlockShape().begin(),
                                         op.getBlockShape().end());

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -153,11 +153,14 @@ public:
                             llvmStruct.getBody()[j], ptr, ValueRange{idx});
           b.store(elem, gep);
         }
+
+        loopIterArgs[idx] = newIterArgVal;
+      } else {
+        // this will probably be overwritten when we next compute block
+        // arguments, but that's ok -- or is it? do we need to get the next tile
+        // for the iter arg here?
+        loopIterArgs[idx] = newIterArgVals[idx];
       }
-      // this will probably be overwritten when we next compute block arguments,
-      // but that's ok -- or is it? do we need to get the next tile for the iter
-      // arg here?
-      loopIterArgs[idx] = newIterArgVals[idx];
     }
   }
 
@@ -458,8 +461,6 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
       Type tritonType = op.getIterArg(i).getType();
       Type llvmType = getTypeConverter()->convertType(tritonType);
 
-      // TODO: create alloca backed buffers corresponding to init arg and copy
-      // init arg in if we have a tensor type.
       args.emplace_back(ArgInfo(ArgInfo::Kind::IterArg, tritonType, llvmType,
                                 op.getInitVals()[i]));
     }

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -83,8 +83,8 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const ArgInfo &a) {
 
 class LoopHelper {
 public:
-  LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset, cpu::GenericOp generic,
-             const TypeConverter *typeConverter,
+  LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset, Value iterArgOffset,
+             cpu::GenericOp generic, const TypeConverter *typeConverter,
              ConversionPatternRewriter &rewriter);
 
   SmallVector<Value> getEntryArgs() {
@@ -99,6 +99,11 @@ public:
   void incrementFlatOffset(ConversionPatternRewriter &rewriter, Value inc) {
     auto b = TritonLLVMOpBuilder(flatOffset.getLoc(), rewriter);
     flatOffset = b.add(flatOffset, inc);
+  }
+
+  void incrementIterArgOffset(ConversionPatternRewriter &rewriter, Value inc) {
+    auto b = TritonLLVMOpBuilder(flatOffset.getLoc(), rewriter);
+    iterArgOffset = b.add(iterArgOffset, inc);
   }
 
   // build loop body block arguments for the current loop level. Adds
@@ -167,7 +172,7 @@ public:
             for (unsigned j = 0; j < llvmStruct.getBody().size(); ++j) {
               Value elem =
                   b.extract_val(llvmStruct.getBody()[j], castedYieldVal, j);
-              Value idx = b.add(flatOffset, b.i32_val(j));
+              Value idx = b.add(iterArgOffset, b.i32_val(j));
               Value gep =
                   b.gep(ptr_ty(rewriter.getContext()), llvmStruct.getBody()[j],
                         arg.bufferPtr, ValueRange{idx});
@@ -262,27 +267,29 @@ public:
     return ret;
   }
 
+  bool isReductionDim(unsigned d) const {
+    return llvm::is_contained(reductionDims, d);
+  }
+
 private:
   SmallVector<ArgInfo> args;
   SmallVector<Value> loopIterArgs;
-
-  SmallVector<Value>
-      tensorIterArgs; // remove? this is being stored in the args list
-
-  // DenseMap<unsigned, unsigned> loopIterArgsToArgInfo;
 
   SmallVector<Value> materializedResults;
   SmallVector<Type> materializedResultElementTypes;
 
   SmallVector<Value> tileOffsets;
   Value flatOffset;
+  Value iterArgOffset;
+  SmallVector<int32_t> reductionDims;
 };
 
 LoopHelper::LoopHelper(ArrayRef<ArgInfo> args, Value flatOffset,
-                       cpu::GenericOp generic,
+                       Value iterArgOffset, cpu::GenericOp generic,
                        const TypeConverter *typeConverter,
                        ConversionPatternRewriter &rewriter)
-    : args(args.begin(), args.end()), flatOffset(flatOffset) {
+    : args(args.begin(), args.end()), flatOffset(flatOffset),
+      iterArgOffset(flatOffset), reductionDims(generic.getReductionDims()) {
 
   for (auto [idx, arg] : llvm::enumerate(this->args)) {
     if (arg.kind == ArgInfo::Kind::IterArg) {
@@ -389,7 +396,7 @@ LoopHelper::getLoopBodyBlockArgs(ConversionPatternRewriter &rewriter,
         auto b = TritonLLVMOpBuilder(arg.operand.getLoc(), rewriter);
 
         for (unsigned j = 0; j < tileStructTy.getBody().size(); ++j) {
-          Value globalIdx = b.add(flatOffset, b.i32_val(j));
+          Value globalIdx = b.add(iterArgOffset, b.i32_val(j));
           Value gep = b.gep(LLVM::LLVMPointerType::get(rewriter.getContext()),
                             elemTy, arg.bufferPtr, ValueRange{globalIdx});
           Value elem = b.load(elemTy, gep);
@@ -833,10 +840,27 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
     // emit single loop, recurse to next dimension
     Value numChunks = b.sdiv(blockShape[dim], b.i32_val(tileShape[dim]));
 
+    // TODO: can we encapsulate this in the loop helper?
     Value innerStride = b.i32_val(vectorSize);
     for (unsigned d = dim + 1; d < rank; ++d)
       innerStride =
           b.mul(innerStride, b.sdiv(blockShape[d], b.i32_val(tileShape[d])));
+    Value innerIterArgStride = b.i32_val(0);
+    if (!helper.isReductionDim(dim)) {
+      unsigned innerArgVectorSize = 1;
+      // TODO: don't recompute this over and over
+      for (unsigned d = 0; d < tileShape.size(); ++d) {
+        if (!helper.isReductionDim(d)) {
+          innerArgVectorSize *= tileShape[d];
+        }
+      }
+      innerIterArgStride = b.i32_val(innerArgVectorSize);
+      for (unsigned d = dim + 1; d < rank; ++d)
+        if (!helper.isReductionDim(d))
+          innerIterArgStride =
+              b.mul(innerIterArgStride,
+                    b.sdiv(blockShape[d], b.i32_val(tileShape[d])));
+    }
 
     auto finalCarried = emitSingleLoop(
         rewriter, loc, numChunks, tileShape[dim], helper.getIterArgVals(),
@@ -846,6 +870,8 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
 
           auto bb = TritonLLVMOpBuilder(loc, rewriter);
           helper.incrementFlatOffset(rewriter, bb.mul(loopI, innerStride));
+          helper.incrementIterArgOffset(rewriter,
+                                        bb.mul(loopI, innerIterArgStride));
           SmallVector<Value> innerIterArgVals(currentCarried.begin(),
                                               currentCarried.end());
 
@@ -935,8 +961,9 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
              "expected blockShape and tileShape to have "
              "the same rank");
       auto b = TritonLLVMOpBuilder(loc, rewriter);
-      LoopHelper helper(argInfos, /*flatOffset=*/b.i32_val(0), op,
-                        getTypeConverter(), rewriter);
+      LoopHelper helper(argInfos, /*flatOffset=*/b.i32_val(0),
+                        /*iterArgOffset=*/b.i32_val(0), op, getTypeConverter(),
+                        rewriter);
       emitUnrolled(op, helper, rewriter, numChunks, vectorSize, blockShape,
                    tileShape);
       results = helper.getResults();
@@ -955,8 +982,9 @@ struct GenericOpConversion : public ConvertOpToLLVMPattern<cpu::GenericOp> {
                                    "generic ops on dynamic path");
 
       auto b = TritonLLVMOpBuilder(loc, rewriter);
-      LoopHelper helper(argInfos, /*flatOffset=*/b.i32_val(0), op,
-                        getTypeConverter(), rewriter);
+      LoopHelper helper(argInfos, /*flatOffset=*/b.i32_val(0),
+                        /*iterArgOffset=*/b.i32_val(0), op, getTypeConverter(),
+                        rewriter);
       SmallVector<Value> blockShapeVals(op.getBlockShape().begin(),
                                         op.getBlockShape().end());
       emitNestedLoops(op, helper, rewriter, /*dim=*/0, blockShapeVals,

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -218,20 +218,13 @@ def get_hip_autotune_config():
 
 
 def get_cpu_autotune_config():
-    sizes = [
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 16, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 1},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 4},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 16, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 4},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 4},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 4},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 8, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 6},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 16, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 6},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 6},
-        {'BLOCK_SIZE_M': 4, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 8, 'GROUP_SIZE_M': 6},
-    ]
+    sizes = [{'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 6},  # wider N — biggest win
+             {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6},  # wider N + deeper K
+             {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6},  # deeper K only
+             {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 4},  # large block
+             {'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M':
+              6},  # smaller M if L1 is tight
+             ]
     return [triton.Config(s | {'matrix_instr_nonkdim': 16}, num_warps=1, num_stages=2) for s in sizes]
 
 


### PR DESCRIPTION
Adds a new fusion pass in tile and fuse that replaces a dot-op wrapping generic inside a K loop with a dot-op wrapping generic that also iterates over k. This differs from fusing the K loop in that the bounds of the K loop become part of the generic block/tile shape. The primary advantage is we maintain the existing K -> M -> N loop order (within the blocks) which is optimal for A operand memory re-use. 

