### PR TITLE
Support arith::SIToFPOp conversion to LLVM

### DIFF
--- a/.github/workflows/integration-tests-cpu.yml
+++ b/.github/workflows/integration-tests-cpu.yml
@@ -124,7 +124,9 @@ jobs:
       - name: Run python tests on CPU
         working-directory: ./triton
         run: |
-          TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "test_bin_op"
+          pip install -r python/test-requirements.txt
+
+          TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest -n 4 --device "cpu" python/test/unit/language/test_core.py -k "test_bin_op"
           TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "(test_reduce1d or test_generic_reduction or test_load_store_same_ptr)"
           TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "(test_unary_op or test_math_op or test_abs[ or test_store_constant or test_split or test_convert_float16_to_float32 or test_optimize_thread_locality or test_full or test_const[ or test_masked_load[ or test_masked_load_scalar[ or test_vectorization[ or test_assume or test_value_specialization or test_bin_op_constexpr or test_call or test_if[ or test_map_elementwise or test_for_iv or test_if_else or test_while or test_nested_while or test_propagate_nan[m or test_static_range or test_unsplat)"
           TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "test_interleave and not test_interleave_scalars"

--- a/.github/workflows/integration-tests-cpu.yml
+++ b/.github/workflows/integration-tests-cpu.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Run python tests on CPU
         working-directory: ./triton
         run: |
+          TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "test_bin_op"
           TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "(test_reduce1d or test_generic_reduction or test_load_store_same_ptr)"
           TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "(test_unary_op or test_math_op or test_abs[ or test_store_constant or test_split or test_convert_float16_to_float32 or test_optimize_thread_locality or test_full or test_const[ or test_masked_load[ or test_masked_load_scalar[ or test_vectorization[ or test_assume or test_value_specialization or test_bin_op_constexpr or test_call or test_if[ or test_map_elementwise or test_for_iv or test_if_else or test_while or test_nested_while or test_propagate_nan[m or test_static_range or test_unsplat)"
           TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "test_interleave and not test_interleave_scalars"

--- a/cpu/lib/TritonCPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -22,6 +22,86 @@ struct FDivOpConversion
   }
 };
 
+static Value checkIsNan(TritonLLVMOpBuilder &builder, Value v) {
+  Location loc = builder.loc;
+  OpBuilder &rewriter = *builder.builder;
+
+  // bits 0 and 1 indicate signaling Nan and quiet Nan, respectively
+  IntegerAttr controlBits = rewriter.getIntegerAttr(i32_ty, 0b11);
+  return LLVM::IsFPClass::create(rewriter, loc, i1_ty, v, controlBits);
+}
+
+static Value convertFp32ToBf16(Location loc,
+                               ConversionPatternRewriter &rewriter,
+                               const Value &v, const RoundingMode rounding) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto as_int32 = b.bitcast(v, i32_ty);
+  if (rounding == RoundingMode::RTZ) {
+    auto shifted = b.lshr(i32_ty, as_int32, b.i32_val(16));
+    auto truncated = b.trunc(i16_ty, shifted);
+    return b.bitcast(truncated, bf16_ty);
+  }
+
+  // This implementation is a faster version for fp32 to bf16 type conversion
+  // It is from CK:
+  // https://github.com/cgmillette/composable_kernel/commit/24e75bef6aa5
+  // It uses less VGPR and less number of instructions compared to the
+  // previous implementation
+  Value isNan = checkIsNan(b, v);
+  Value v16 = b.i32_val(16);
+  Value tmp = b.and_(i32_ty, b.lshr(i32_ty, as_int32, v16), b.i32_val(1));
+
+  Value v7FFF = b.i32_val(0x7FFF);
+  Value s1 = b.add(as_int32, tmp);
+  Value s2 = b.add(s1, v7FFF);
+
+  Value vNan = b.i32_val(0x7FFF0000);
+  Value res = b.select(isNan, vNan, s2);
+
+  Value shifted = b.lshr(i32_ty, res, v16);
+  Value truncated = b.trunc(i16_ty, shifted);
+  return b.bitcast(truncated, bf16_ty);
+}
+
+static SmallVector<Value> S8_to_Bf16(Location loc,
+                                     ConversionPatternRewriter &rewriter,
+                                     const SmallVector<Value> &v) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  SmallVector<Value> inValues = {v[0], v[1], v[2], v[3]};
+  SmallVector<Value> outValues = {};
+  for (Value inVal : inValues) {
+    Value bf16Val = LLVM::SIToFPOp::create(rewriter, loc, bf16_ty, inVal);
+    outValues.push_back(bf16Val);
+  }
+  return outValues;
+}
+
+struct SIToFPOpConversion
+    : ElementwiseOpConversionBase<arith::SIToFPOp, SIToFPOpConversion> {
+  using ElementwiseOpConversionBase::ElementwiseOpConversionBase;
+
+  SmallVector<Value> createDestOps(arith::SIToFPOp op, OpAdaptor adaptor,
+                                   ConversionPatternRewriter &rewriter,
+                                   Type elemTy, MultipleOperandsRange operands,
+                                   Location loc) const {
+    Type inElemTy = getElementTypeOrSelf(op.getIn());
+    Type outElemTy = getElementTypeOrSelf(op.getOut());
+    if (outElemTy.isBF16() && inElemTy.isInteger(8) && operands.size() >= 4) {
+      SmallVector<Value> inVals = {operands[0][0], operands[1][0],
+                                   operands[2][0], operands[3][0]};
+      auto outVals = S8_to_Bf16(loc, rewriter, inVals);
+      assert(outVals.size() == 4);
+      return outVals;
+    } else if (outElemTy.isBF16()) {
+      auto value =
+          LLVM::SIToFPOp::create(rewriter, loc, f32_ty, operands[0][0]);
+      return {convertFp32ToBf16(loc, rewriter, value, RoundingMode::RTNE)};
+    } else {
+      return {LLVM::SIToFPOp::create(rewriter, loc, elemTy, operands[0][0])};
+    }
+  }
+};
+
 } // namespace
 
 void mlir::triton::cpu::populateElementwiseOpToLLVMPatterns(
@@ -30,6 +110,7 @@ void mlir::triton::cpu::populateElementwiseOpToLLVMPatterns(
     PatternBenefit benefit) {
 
   patterns.add<FDivOpConversion>(typeConverter, axisInfoAnalysis, benefit);
+  patterns.add<SIToFPOpConversion>(typeConverter, axisInfoAnalysis, benefit);
 
   mlir::triton::populateElementwiseOpToLLVMPatterns(
       typeConverter, patterns, axisInfoAnalysis, targetInfo, benefit);


### PR DESCRIPTION
This allow us to run all `test_bin_op` unit tests. 