### PR TITLE
[GenericOp] Properly handle slice layouts in MakeRange fusion and unrolled LLVM lowering

### DIFF
--- a/.github/workflows/integration-tests-cpu.yml
+++ b/.github/workflows/integration-tests-cpu.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   integration-tests-cpu:
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       matrix:
         runner: ${{ fromJson(inputs.matrix) }}
@@ -127,7 +127,7 @@ jobs:
           pip install -r python/test-requirements.txt
 
           TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest -n 4 --device "cpu" python/test/unit/language/test_core.py -k "test_bin_op"
-          TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "(test_reduce1d or test_generic_reduction or test_load_store_same_ptr)"
+          TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest -n 4 --device "cpu" python/test/unit/language/test_core.py -k "(test_reduce or test_generic_reduction or test_load_store_same_ptr)"
           TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "(test_unary_op or test_math_op or test_abs[ or test_store_constant or test_split or test_convert_float16_to_float32 or test_optimize_thread_locality or test_full or test_const[ or test_masked_load[ or test_masked_load_scalar[ or test_vectorization[ or test_assume or test_value_specialization or test_bin_op_constexpr or test_call or test_if[ or test_map_elementwise or test_for_iv or test_if_else or test_while or test_nested_while or test_propagate_nan[m or test_static_range or test_unsplat)"
           TRITON_CPU_ENABLE_TILE_AND_FUSE=1 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "test_interleave and not test_interleave_scalars"
           TRITON_CPU_WARP_SIZE=4 python -m pytest --device "cpu" python/test/unit/language/test_core.py -k "(test_reduce1d or test_load_store_same_ptr) and not test_reduce1d[1-sum-float16-512]"

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -668,12 +668,21 @@ struct FuseMakeRangeIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
                               "should be inside a 1D generic");
           dim = 0;
         } else {
-          // Body induction vars are ordered outermost-first, matching
-          // blockShape. A SliceEncodingAttr with dim=d encodes a 1D tensor in
-          // the direction of tensor-dim (1-d),
-          // which sits at blockShape index (rank-2) + (1-d) = rank-1-d.
-          dim =
-              genericOp.getBlockShape().size() - 1 - sliceEncodingAttr.getDim();
+          SmallVector<unsigned> sliceDims;
+          Attribute enc = sliceEncodingAttr;
+          while (auto sliceEnc = dyn_cast<gpu::SliceEncodingAttr>(enc)) {
+            sliceDims.push_back(sliceEnc.getDim());
+            enc = sliceEnc.getParent();
+          }
+          // sliceDims is outermost-first; process innermost-first (reversed)
+          SmallVector<unsigned> survivingDims;
+          for (unsigned i = 0; i < genericOp.getBlockShape().size(); ++i)
+            survivingDims.push_back(i);
+          for (auto d : llvm::reverse(sliceDims))
+            survivingDims.erase(survivingDims.begin() + d);
+          assert(survivingDims.size() == 1 &&
+                 "expected single surviving dim for make_dynamic_range");
+          dim = survivingDims.front();
         }
         newOp = triton::cpu::MakeDynamicRangeOp::create(
             rewriter, makeRangeOp.getLoc(), newResultType,

--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -243,7 +243,7 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
       return failure();
 
     // Wrap scalar reductions in ttc.generic. Take the elementwise chain as
-    // input.
+    // input. // TODO: relax this
     auto reduceResult = reduceOp.getResult();
     if (reduceResult.size() != 1)
       return failure();
@@ -301,10 +301,10 @@ struct WrapReduceOp : public mlir::OpRewritePattern<triton::ReduceOp> {
                                               neutralVal.value());
     SmallVector<Value> initVals = {newAccum.getResult()};
 
-    auto generic =
-        cpu::GenericOp::create(rewriter, loc, resultTypes, initVals, insValues,
-                               blockShapeValues, tileShape,
-                               /*reductionDims=*/{0});
+    auto generic = cpu::GenericOp::create(
+        rewriter, loc, resultTypes, initVals, insValues, blockShapeValues,
+        tileShape,
+        /*reductionDims=*/{static_cast<int32_t>(reduceOp.getAxis())});
 
     IRMapping bodyMapping;
     initGenericBody(rewriter, generic, ins, {initVals[0].getType()}, tileShape,

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -1,10 +1,12 @@
+#include "PatternTritonGPUOpToLLVM.h"
 #include "TargetInfo.h"
 
-#include "cpu/include/Dialect/TritonCPU/IR/Dialect.h"
-#include "mlir/Transforms/DialectConversion.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
-#include "PatternTritonGPUOpToLLVM.h"
+#include "cpu/include/Dialect/TritonCPU/IR/Dialect.h"
+
+#include "mlir/Transforms/DialectConversion.h"
+
 #include <functional>
 #include <numeric>
 
@@ -312,14 +314,56 @@ SmallVector<Value> LoopHelper::getLoopBodyBlockArgs(
           LinearLayout tileLayout = triton::gpu::toLinearLayout(tensorTy);
 
           // get the starting register index for this tile in the source tensor
+          auto globalTensorTy =
+              cast<RankedTensorType>(argInfo.operand.getType());
           LinearLayout srcLayout =
-              triton::gpu::toLinearLayout(
-                  cast<RankedTensorType>(argInfo.operand.getType()))
-                  .pseudoinvert();
-          SmallVector<std::pair<StringAttr, int32_t>> srcLayoutOffsets;
+              triton::gpu::toLinearLayout(globalTensorTy).pseudoinvert();
+          llvm::errs() << "orig src layout: " << srcLayout << "\n";
+          // TODO: should this be recursive?
+          if (srcLayout.getNumInDims() < elemOffset.size()) {
+            auto sliceEncoding = dyn_cast<triton::gpu::SliceEncodingAttr>(
+                globalTensorTy.getEncoding());
+            assert(sliceEncoding == tensorTy.getEncoding());
+            srcLayout = triton::gpu::toLinearLayout(
+                sliceEncoding.paddedShape(globalTensorTy.getShape()),
+                sliceEncoding.getParent());
+
+            llvm::errs() << "src layout pre inversion: " << srcLayout << "\n";
+            srcLayout = srcLayout.removeZeroBasesAlongDim(kRegister);
+            llvm::errs() << "src layout after removing zero bases: "
+                         << srcLayout << "\n";
+
+            srcLayout = srcLayout.pseudoinvert();
+
+            tileLayout = triton::gpu::toLinearLayout(
+                sliceEncoding.paddedShape(tensorTy.getShape()),
+                sliceEncoding.getParent());
+
+            auto bases = tileLayout.getBases();
+            std::vector<std::vector<int>> newRegBases;
+            for (const auto &basis : bases[kRegister]) {
+              if (llvm::any_of(basis, [](int b) { return b != 0; })) {
+                newRegBases.push_back(basis);
+              }
+            }
+            bases[kRegister] = newRegBases;
+            tileLayout = LinearLayout(
+                std::move(bases), llvm::to_vector(tileLayout.getOutDimNames()));
+
+            LLVM_DEBUG({
+              DBGS() << "Reset srcLayout using slice parent "
+                     << sliceEncoding.getParent() << "\n  for type "
+                     << globalTensorTy << "\n";
+              DBGS() << "New global layout: " << srcLayout << "\n";
+              DBGS() << "New tile layout: " << tileLayout << "\n";
+            });
+          }
+
           assert(srcLayout.getNumInDims() == elemOffset.size() &&
                  "expected number of tile element offsets to match source "
                  "layout in dims");
+
+          SmallVector<std::pair<StringAttr, int32_t>> srcLayoutOffsets;
           for (auto [dim, layoutOffset] :
                llvm::zip(srcLayout.getInDimNames(), elemOffset)) {
             // the srcLayout is inverted, so map to the tile layouts out dims to
@@ -338,9 +382,15 @@ SmallVector<Value> LoopHelper::getLoopBodyBlockArgs(
 
           // Compose tileLayout with srcLayout to map tile_register to registers
           // in the global tensor
-          LinearLayout tileToFullSrc =
-              tileLayout.compose(srcLayout).flattenIns();
+          // TODO: reset layouts here to describe the actual encoding??
+          LinearLayout tileToFullSrc = tileLayout.compose(srcLayout);
+          LDBG("tile to full src layout: " << tileToFullSrc);
+          tileToFullSrc = tileToFullSrc.flattenIns().flattenOuts();
+          LDBG("flat tile to full src layout: " << tileToFullSrc);
           auto flatDimName = llvm::to_vector(tileToFullSrc.getInDimNames())[0];
+          // This is no good, becuase the register space still jumps by 8s...
+          // tileToFullSrc = tileToFullSrc.removeZeroBasesAlongDim(flatDimName);
+          // LDBG("flat tile without broadcast: " << tileToFullSrc);
 
           LDBG("tile for loop index " << loopIndex.value()
                                       << " has origin register " << origin);

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -318,37 +318,33 @@ SmallVector<Value> LoopHelper::getLoopBodyBlockArgs(
               cast<RankedTensorType>(argInfo.operand.getType());
           LinearLayout srcLayout =
               triton::gpu::toLinearLayout(globalTensorTy).pseudoinvert();
-          llvm::errs() << "orig src layout: " << srcLayout << "\n";
-          // TODO: should this be recursive?
+
           if (srcLayout.getNumInDims() < elemOffset.size()) {
+            // for tensors with sliced encoding we restore the sliced dimension
+            // with size 1 which allows us to pass the elem offsets directly.
+            // The sliced dimension has no effect on the position of the sliced
+            // tile within the original sliced tensor.
             auto sliceEncoding = dyn_cast<triton::gpu::SliceEncodingAttr>(
                 globalTensorTy.getEncoding());
             assert(sliceEncoding == tensorTy.getEncoding());
+
+            // compute a linear layout representing the parent encoding but
+            // uisng the sliced encoding padded shape (i.e. slice dim set to 1)
             srcLayout = triton::gpu::toLinearLayout(
                 sliceEncoding.paddedShape(globalTensorTy.getShape()),
                 sliceEncoding.getParent());
-
-            llvm::errs() << "src layout pre inversion: " << srcLayout << "\n";
+            // remove any register padded added by toLinearLayout for the parent
+            // encoding (e.g. if sizePerThread > 1 in the sliced dimension) and
+            // invert the layout
             srcLayout = srcLayout.removeZeroBasesAlongDim(kRegister);
-            llvm::errs() << "src layout after removing zero bases: "
-                         << srcLayout << "\n";
-
+            // and invert
             srcLayout = srcLayout.pseudoinvert();
 
+            // repeat for the tile layout
             tileLayout = triton::gpu::toLinearLayout(
                 sliceEncoding.paddedShape(tensorTy.getShape()),
                 sliceEncoding.getParent());
-
-            auto bases = tileLayout.getBases();
-            std::vector<std::vector<int>> newRegBases;
-            for (const auto &basis : bases[kRegister]) {
-              if (llvm::any_of(basis, [](int b) { return b != 0; })) {
-                newRegBases.push_back(basis);
-              }
-            }
-            bases[kRegister] = newRegBases;
-            tileLayout = LinearLayout(
-                std::move(bases), llvm::to_vector(tileLayout.getOutDimNames()));
+            tileLayout = tileLayout.removeZeroBasesAlongDim(kRegister);
 
             LLVM_DEBUG({
               DBGS() << "Reset srcLayout using slice parent "
@@ -379,22 +375,20 @@ SmallVector<Value> LoopHelper::getLoopBodyBlockArgs(
           assert(originOffset.first == kRegister &&
                  "expected origin offset to be in the register space");
           int32_t origin = originOffset.second;
-
-          // Compose tileLayout with srcLayout to map tile_register to registers
-          // in the global tensor
-          // TODO: reset layouts here to describe the actual encoding??
-          LinearLayout tileToFullSrc = tileLayout.compose(srcLayout);
-          LDBG("tile to full src layout: " << tileToFullSrc);
-          tileToFullSrc = tileToFullSrc.flattenIns().flattenOuts();
-          LDBG("flat tile to full src layout: " << tileToFullSrc);
-          auto flatDimName = llvm::to_vector(tileToFullSrc.getInDimNames())[0];
-          // This is no good, becuase the register space still jumps by 8s...
-          // tileToFullSrc = tileToFullSrc.removeZeroBasesAlongDim(flatDimName);
-          // LDBG("flat tile without broadcast: " << tileToFullSrc);
-
           LDBG("tile for loop index " << loopIndex.value()
                                       << " has origin register " << origin);
 
+          // Compose tileLayout with srcLayout to map tile_register to registers
+          // in the global tensor
+          // Note that we flatten both dimensions to remove lane, warp, and
+          // block which are all equal to 1. This gives us a tile register <->
+          // source tensor mapping
+          LinearLayout tileToFullSrc =
+              tileLayout.compose(srcLayout).flattenIns().flattenOuts();
+          LDBG("Tile to source tensor register mapping layout: "
+               << tileToFullSrc);
+
+          auto flatDimName = llvm::to_vector(tileToFullSrc.getInDimNames())[0];
           for (unsigned j = 0; j < tileToFullSrc.getInDimSize(flatDimName);
                ++j) {
             auto relRegOffset = tileToFullSrc.apply({{flatDimName, j}}).front();

--- a/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/GenericOpToLLVM.cpp
@@ -388,10 +388,8 @@ SmallVector<Value> LoopHelper::getLoopBodyBlockArgs(
           LDBG("Tile to source tensor register mapping layout: "
                << tileToFullSrc);
 
-          auto flatDimName = llvm::to_vector(tileToFullSrc.getInDimNames())[0];
-          for (unsigned j = 0; j < tileToFullSrc.getInDimSize(flatDimName);
-               ++j) {
-            auto relRegOffset = tileToFullSrc.apply({{flatDimName, j}}).front();
+          for (unsigned j = 0; j < tileToFullSrc.getTotalInDimSize(); ++j) {
+            auto relRegOffset = tileToFullSrc.apply({{kRegister, j}}).front();
             assert(relRegOffset.first == kRegister &&
                    "expected offset to be in the register space");
             int32_t srcReg = origin ^ relRegOffset.second;


### PR DESCRIPTION
Fixes two bugs which allow all previously failing reduction tests to pass under TileAndFuse. 

* `MakeRangeOp` fusion now handles nested `SliceEncodingAttr` layouts
* Reading slice-encoded tiles in the unrolled path properly reconstructs a full-rank tensor for sliced layouts. The sliced dimension is padded to 1 but the padding is removed in the layout register space. This results in an appropriately ranked tensor, but the value for the padded dimension is ignored - exactly what we want when loading a sliced tile from a sliced global tensor. 

I also enabled all reduction tests in GitHub Actions. I used parallel jobs but also bumped the timeout from 60m to 90m, as the addition reduction tests will add a few mins and we were pretty close to 60 to begin with. 