### PR TITLE
Allow fusing read only elementwise-like operations across blocks

### DIFF
--- a/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/TileAndFuse.cpp
@@ -4,6 +4,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/Support/Debug.h"
@@ -563,8 +564,17 @@ struct FuseElementwiseIntoGeneric : mlir::OpRewritePattern<cpu::GenericOp> {
         continue;
 
       if (!mlir::isMemoryEffectFree(op) &&
-          op->getBlock() != genericOp->getBlock())
-        continue;
+          op->getBlock() != genericOp->getBlock()) {
+        // A read-only op that dominates the generic is safe to clone because
+        // its inputs are already available and its loads observe the same
+        // memory regardless of how many times they execute.
+        DominanceInfo domInfo(genericOp->getParentOfType<FuncOp>());
+
+        bool readOnly = !mlir::hasEffect<mlir::MemoryEffects::Write>(op) &&
+                        !mlir::hasEffect<mlir::MemoryEffects::Allocate>(op);
+        if (!readOnly || !domInfo.dominates(op, genericOp))
+          continue;
+      }
 
       BlockArgument blockArg = body->getArgument(numIV + i);
       auto tiledType = dyn_cast<RankedTensorType>(blockArg.getType());

--- a/test/Transform/tile_and_fuse.mlir
+++ b/test/Transform/tile_and_fuse.mlir
@@ -35,20 +35,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 
 // -----
 
-// Memory-effect ops (tt.load) defined in an outer block must not be fused
-// into a ttc.generic that lives in an inner block, even though tt.load is
-// otherwise considered fusible. The load must remain as a generic ins arg.
+// A read-only tt.load defined in an outer block IS fused into a ttc.generic
+// that lives in an inner block, because the load dominates the generic and
+// has no write effects. The load's block (the function body) dominates the
+// for-loop body where the generic lives, so cloning it per-tile is safe.
 //
-// CHECK-LABEL: tt.func public @test_no_cross_block_load_fusion
-// CHECK:       tt.load
+// CHECK-LABEL: tt.func public @test_cross_block_dominating_load_fused
+// CHECK-NOT:   tt.load
 // CHECK:       scf.for
 // CHECK:         ttc.generic
-// CHECK-NOT:       tt.load
+// CHECK:           tt.load
 // CHECK:           tt.store
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [1], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
-  tt.func public @test_no_cross_block_load_fusion(%val_ptr: !tt.ptr<f32>, %out_ptr: !tt.ptr<f32>) attributes {noinline = false} {
+  tt.func public @test_cross_block_dominating_load_fused(%val_ptr: !tt.ptr<f32>, %out_ptr: !tt.ptr<f32>) attributes {noinline = false} {
     %c0 = arith.constant 0 : i32
     %c1 = arith.constant 1 : i32
     %c4 = arith.constant 4 : i32
@@ -57,6 +58,54 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     %val_ptrs = tt.addptr %val_base, %offsets : tensor<4x!tt.ptr<f32>, #blocked>, tensor<4xi32, #blocked>
     %data = tt.load %val_ptrs : tensor<4x!tt.ptr<f32>, #blocked>
     scf.for %i = %c0 to %c4 step %c1 : i32 {
+      %out_base = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>, #blocked>
+      %out_ptrs = tt.addptr %out_base, %offsets : tensor<4x!tt.ptr<f32>, #blocked>, tensor<4xi32, #blocked>
+      tt.store %out_ptrs, %data : tensor<4x!tt.ptr<f32>, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// A tt.load inside a nested for-loop body is NOT fused into a ttc.generic
+// that lives in an outer block. The load's block (the inner for-loop body)
+// does not dominate the generic's block (the outer for-loop body), so the
+// loaded value can only reach the generic via the inner for-loop's result —
+// whose definingOp is scf.for, which is not fusible. The load therefore
+// stays in the inner loop.
+//
+// CHECK-LABEL: tt.func public @test_no_fusion_load_in_non_dominating_block
+// CHECK:       scf.for
+// CHECK:         tt.load
+// CHECK:       scf.for
+// CHECK:         ttc.generic
+// CHECK-NOT:       tt.load
+// CHECK:           tt.store
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [1], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cpu", "ttg.threads-per-warp" = 1 : i32} {
+  tt.func public @test_no_fusion_load_in_non_dominating_block(%val_ptr: !tt.ptr<f32>, %num_iters: index, %out_ptr: !tt.ptr<f32>) attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c4 = arith.constant 4 : i32
+    %offsets = tt.make_range {start = 0 : i32, end = 4 : i32} : tensor<4xi32, #blocked>
+    %val_base = tt.splat %val_ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>, #blocked>
+    %val_ptrs = tt.addptr %val_base, %offsets : tensor<4x!tt.ptr<f32>, #blocked>, tensor<4xi32, #blocked>
+    %init = arith.constant dense<0.0> : tensor<4xf32, #blocked>
+    // scf.for requires index-typed bounds when iter_args are present.
+    %c0_idx = arith.constant 0 : index
+    %c1_idx = arith.constant 1 : index
+    // Load is inside an inner for-loop body — a block that does NOT dominate
+    // the outer for-loop body where the generic will be placed.
+    %data = scf.for %i = %c0_idx to %num_iters step %c1_idx iter_args(%acc = %init) -> (tensor<4xf32, #blocked>) {
+      %loaded = tt.load %val_ptrs : tensor<4x!tt.ptr<f32>, #blocked>
+      scf.yield %loaded : tensor<4xf32, #blocked>
+    }
+    // Store (and the generic it becomes) lives in the outer for-loop body.
+    // The generic's ins for the data is the scf.for result, which is not a
+    // fusible elementwise op — fusion is not attempted.
+    scf.for %j = %c0 to %c4 step %c1 : i32 {
       %out_base = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>, #blocked>
       %out_ptrs = tt.addptr %out_base, %offsets : tensor<4x!tt.ptr<f32>, #blocked>, tensor<4xi32, #blocked>
       tt.store %out_ptrs, %data : tensor<4x!tt.ptr<f32>, #blocked>


### PR DESCRIPTION
A read-only op that dominates the generic is safe to clone because its inputs are already available and its loads observe the same memory regardless of how many times they execute.