### PR TITLE
Always run OptimizeBlockedLayout pattern in Accelerate Matmul

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -165,8 +165,7 @@ class CPUBackend(BaseBackend):
         passes.ttir.add_convert_to_ttgpuir(pm, "cpu", options.num_warps, options.warp_size, num_ctas)
         cpu.passes.ttgpuir.add_coalesce(pm, max_vector_width=cpu.get_max_vector_width_bits(options.features))
         passes.ttgpuir.add_remove_layout_conversions(pm)
-        cpu.passes.ttgpuir.add_accelerate_matmul(pm, optimize_block_layout=True,
-                                                 canonicalize_k_loop=options.tile_and_fuse)
+        cpu.passes.ttgpuir.add_accelerate_matmul(pm, canonicalize_k_loop=options.tile_and_fuse)
         passes.ttgpuir.add_remove_layout_conversions(pm)
 
         passes.ttgpuir.add_optimize_thread_locality(pm)

--- a/cpu/include/Dialect/TritonCPU/Transforms/Passes.td
+++ b/cpu/include/Dialect/TritonCPU/Transforms/Passes.td
@@ -16,9 +16,6 @@ def TritonCPUAccelerateMatmul : Pass<"tritoncpu-accelerate-matmul", "mlir::Modul
   }];
 
   let options = [
-    Option<"optimizeBlockLayout", "optimize-block-layout", "bool",
-           /*default=*/"false",
-           "Rewrite tensor block layouts for improved memory access patterns">,
     Option<"canonicalizeKLoop", "canonicalize-k-loop", "bool",
            /*default=*/"true",
            "Canonicalize K-loop pointer iter args to direct per-iteration "

--- a/cpu/lib/Dialect/TritonCPU/Transforms/AccelerateMatmul.cpp
+++ b/cpu/lib/Dialect/TritonCPU/Transforms/AccelerateMatmul.cpp
@@ -70,7 +70,6 @@ public:
       return failure();
     }
 
-    // TODO: both A and B? or just B? don't want to blow up the register use
     SmallVector<unsigned> newSizePerThread = {*vectorSizeA, *vectorSizeB};
     auto oldSizePerThread = blockedEncoding.getSizePerThread();
     if (llvm::equal(oldSizePerThread, newSizePerThread))
@@ -299,9 +298,7 @@ public:
     ModuleOp m = getOperation();
     mlir::RewritePatternSet patterns(context);
     constexpr int benefitDefault = 1;
-    if (optimizeBlockLayout) {
-      patterns.add<OptimizeBlockedLayout>(context, benefitDefault);
-    }
+    patterns.add<OptimizeBlockedLayout>(context, benefitDefault);
     if (canonicalizeKLoop) {
       patterns.add<CanonicalizeKLoop>(context, benefitDefault + 1);
     }

--- a/test/Transform/accelerate_matmul.mlir
+++ b/test/Transform/accelerate_matmul.mlir
@@ -12,7 +12,8 @@
 // CHECK:           tt.splat [[IV]]
 // CHECK:           arith.muli
 // CHECK:           tt.addptr
-// CHECK:           tt.dot {{.*}}[[ACC]]
+// CHECK:           [[C:%[^ ]+]] = ttg.convert_layout [[ACC]]
+// CHECK:           tt.dot {{.*}}[[C]]
 // CHECK:           scf.yield
 
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [1, 0]}>

--- a/triton_cpu.cc
+++ b/triton_cpu.cc
@@ -71,15 +71,12 @@ void init_triton_cpu_passes(py::module_ &m) {
 void init_triton_cpu_passes_ttgpuir(py::module_ &m) {
   m.def(
       "add_accelerate_matmul",
-      [](mlir::PassManager &pm, bool optimizeBlockLayout,
-         bool canonicalizeKLoop) {
+      [](mlir::PassManager &pm, bool canonicalizeKLoop) {
         mlir::triton::cpu::TritonCPUAccelerateMatmulOptions opts;
-        opts.optimizeBlockLayout = optimizeBlockLayout;
         opts.canonicalizeKLoop = canonicalizeKLoop;
         pm.addPass(mlir::triton::cpu::createTritonCPUAccelerateMatmul(opts));
       },
-      py::arg("pm"), py::arg("optimize_block_layout") = false,
-      py::arg("canonicalize_k_loop") = false);
+      py::arg("pm"), py::arg("canonicalize_k_loop") = false);
   m.def(
       "add_coalesce",
       [](mlir::PassManager &pm, int maxVectorWidth) {


### PR DESCRIPTION
Optimize blocked layout picks the largest block layout compatible with the load, which is desireable with and without tile and fuse enabled.