### PR TITLE
Drop unnecessary address space bitcast

### DIFF
--- a/cpu/lib/TritonCPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/cpu/lib/TritonCPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -357,8 +357,7 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
           rewriter, this->getTypeConverter(), loc, cast<VectorType>(vecTy),
           valueElems, vecStart);
 
-      cpu::llStore(rewriter, loc, b.bitcast(ptrElems[vecStart], ptr_ty(ctx, 1)),
-                   storeVal, pred);
+      cpu::llStore(rewriter, loc, ptrElems[vecStart], storeVal, pred);
     }
     rewriter.eraseOp(op);
     return success();


### PR DESCRIPTION
Not sure what this is from, but the address space part is problematic - a bitcast to a ptr type of a different address space is invalid, and 1 is not likely to be the default for the CPU backend. Rather than fix the address space, we try dropping the bitcast.